### PR TITLE
Add openai-compatible provider baseUrl configuration

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,14 @@
 provider = "anthropic"
 model = "claude-sonnet-4-20250514"
 
+# To use a custom OpenAI-compatible endpoint instead:
+# provider = "openai-compatible"
+# model = "claude-sonnet-4-6"
+# baseUrl = "http://localhost:8317/v1"
+# apiKey = "your-api-key"
+# contextWindow = 200000    # optional, auto-detected for known models
+# maxTokens = 64000         # optional, auto-detected for known models
+
 # Password for HTTP Basic Auth. All endpoints except webhooks require this.
 # Change this to something secure. If removed or commented out, all endpoints
 # are open to the world.

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, type MockedFunction, beforeEach } from "vites
 import type { Agent, AgentMessage, AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { complete } from "@mariozechner/pi-ai";
 import type { Pool } from "pg";
-import { serializeMessagesForSummary, filterToolsForSubagent, formatPluginListSection, truncateContext, createManageKnowledgeTool, injectAutoSearchBlock, pendingAutoSearchBlocks, handlePrompt, createAgent, escalatingSummarize, selectCompactionCutIndex, isTurnBoundary } from "./agent/index.js";
+import { serializeMessagesForSummary, filterToolsForSubagent, formatPluginListSection, truncateContext, createManageKnowledgeTool, injectAutoSearchBlock, pendingAutoSearchBlocks, handlePrompt, createAgent, escalatingSummarize, selectCompactionCutIndex, isTurnBoundary, buildOpenAiCompatModel } from "./agent/index.js";
+import type { Config } from "./config.js";
 import { getApiKey } from "./auth.js";
 import { loadMessages, loadAllMemories, loadAllScratchpadTitles, getMainAgentId } from "./database.js";
 import { runSearch } from "./search.js";
@@ -82,6 +83,8 @@ vi.mock("@mariozechner/pi-ai", () => ({
     Record: vi.fn().mockReturnValue({}),
   },
   getModel: vi.fn().mockReturnValue({ contextWindow: 200000 }),
+  getProviders: vi.fn(),
+  getModels: vi.fn(),
   complete: vi.fn(),
 }));
 // makeMinimalTool is hoisted so it can be used in vi.mock factories below.
@@ -809,6 +812,106 @@ describe("truncateContext", () => {
     const block = (result[0] as { content: Array<{ type: string; text: string }> }).content[0];
     // The block must not have grown: the suffix alone is longer than the original.
     expect(block.text.length).toBeLessThanOrEqual(tinyText.length);
+  });
+});
+
+describe("buildOpenAiCompatModel", () => {
+  async function getProvidersMock(): Promise<MockedFunction<() => string[]>> {
+    const piAi = await import("@mariozechner/pi-ai");
+    return piAi.getProviders as unknown as MockedFunction<() => string[]>;
+  }
+
+  async function getModelsMock(): Promise<MockedFunction<(provider: string) => unknown[]>> {
+    const piAi = await import("@mariozechner/pi-ai");
+    return piAi.getModels as unknown as MockedFunction<(provider: string) => unknown[]>;
+  }
+
+  const baseConfig: Config = {
+    provider: "openai-compatible",
+    model: "claude-sonnet-4-6",
+    apiKey: "test-key",
+    baseUrl: "http://localhost:8317/v1",
+    publicHostname: "https://example.com",
+    baseSystemPrompt: "You are a bot.",
+    compactionPrompt: "Compaction prompt.",
+    compactionBulletPrompt: "Bullet prompt.",
+    baseAgentPrompt: "You are Stavrobot.",
+    compactionTokenThreshold: 80000,
+    owner: { name: "Stavros" },
+  };
+
+  it("uses registry metadata and provider for a known model ID", async () => {
+    const getProviders = await getProvidersMock();
+    const getModels = await getModelsMock();
+
+    getProviders.mockReturnValue(["anthropic"]);
+    getModels.mockReturnValue([
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "anthropic",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+        contextWindow: 200000,
+        maxTokens: 64000,
+      },
+    ]);
+
+    const model = buildOpenAiCompatModel(baseConfig);
+
+    expect(model.api).toBe("openai-completions");
+    expect(model.provider).toBe("anthropic");
+    expect(model.id).toBe("claude-sonnet-4-6");
+    expect(model.name).toBe("Claude Sonnet 4.6");
+    expect(model.contextWindow).toBe(200000);
+    expect(model.maxTokens).toBe(64000);
+    expect(model.baseUrl).toBe("http://localhost:8317/v1");
+  });
+
+  it("falls back to provider 'openai-compatible' and default metadata for an unknown model ID", async () => {
+    const getProviders = await getProvidersMock();
+    const getModels = await getModelsMock();
+
+    getProviders.mockReturnValue(["anthropic"]);
+    getModels.mockReturnValue([]);
+
+    const config: Config = { ...baseConfig, model: "unknown-model-xyz" };
+    const model = buildOpenAiCompatModel(config);
+
+    expect(model.provider).toBe("openai-compatible");
+    expect(model.id).toBe("unknown-model-xyz");
+    expect(model.name).toBe("unknown-model-xyz");
+    expect(model.api).toBe("openai-completions");
+    expect(model.contextWindow).toBe(128000);
+    expect(model.maxTokens).toBe(8192);
+    expect(model.reasoning).toBe(false);
+    expect(model.input).toEqual(["text"]);
+  });
+
+  it("config contextWindow and maxTokens override registry values", async () => {
+    const getProviders = await getProvidersMock();
+    const getModels = await getModelsMock();
+
+    getProviders.mockReturnValue(["anthropic"]);
+    getModels.mockReturnValue([
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "anthropic",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+        contextWindow: 200000,
+        maxTokens: 64000,
+      },
+    ]);
+
+    const config: Config = { ...baseConfig, contextWindow: 50000, maxTokens: 4096 };
+    const model = buildOpenAiCompatModel(config);
+
+    expect(model.contextWindow).toBe(50000);
+    expect(model.maxTokens).toBe(4096);
   });
 });
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import pg from "pg";
-import { Type, getModel, type TextContent, type ImageContent, type AssistantMessage, type ToolCall } from "@mariozechner/pi-ai";
+import { Type, getModel, getProviders, getModels, type TextContent, type ImageContent, type AssistantMessage, type ToolCall } from "@mariozechner/pi-ai";
+import type { Model } from "@mariozechner/pi-ai";
 import { Agent, type AgentTool, type AgentToolResult, type AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Config } from "../config.js";
 import type { FileAttachment } from "../uploads.js";
@@ -394,8 +395,64 @@ function wrapToolWithLogging(tool: AgentTool): AgentTool {
   };
 }
 
+export function buildOpenAiCompatModel(config: Config): Model<"openai-completions"> {
+  // Search the registry for a model whose id matches config.model. The first
+  // match found provides metadata (name, reasoning, input, cost, context sizes).
+  // We keep the original provider so detectCompat() produces the right compat
+  // settings (e.g., "anthropic" for Claude models routed through a proxy).
+  let registryName: string | undefined;
+  let registryReasoning: boolean | undefined;
+  let registryInput: ("text" | "image")[] | undefined;
+  let registryCost: { input: number; output: number; cacheRead: number; cacheWrite: number } | undefined;
+  let registryContextWindow: number | undefined;
+  let registryMaxTokens: number | undefined;
+  let registryProvider: string | undefined;
+
+  for (const provider of getProviders()) {
+    const models = getModels(provider);
+    const match = models.find((m) => m.id === config.model);
+    if (match !== undefined) {
+      registryName = match.name;
+      registryReasoning = match.reasoning;
+      registryInput = match.input;
+      registryCost = match.cost;
+      registryContextWindow = match.contextWindow;
+      registryMaxTokens = match.maxTokens;
+      registryProvider = match.provider as string;
+      log.info(`[stavrobot] openai-compatible: found registry entry for "${config.model}" under provider "${registryProvider}"`);
+      break;
+    }
+  }
+
+  if (registryProvider === undefined) {
+    log.warn(`[stavrobot] openai-compatible: no registry entry found for "${config.model}", using safe defaults`);
+  }
+
+  return {
+    id: config.model,
+    name: registryName ?? config.model,
+    api: "openai-completions" as const,
+    provider: registryProvider ?? "openai-compatible",
+    baseUrl: config.baseUrl as string,
+    reasoning: registryReasoning ?? false,
+    input: registryInput ?? ["text"],
+    cost: registryCost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: config.contextWindow ?? registryContextWindow ?? 128000,
+    maxTokens: config.maxTokens ?? registryMaxTokens ?? 8192,
+  };
+}
+
 export async function createAgent(config: Config, pool: pg.Pool): Promise<Agent> {
-  const model = getModel(config.provider as any, config.model as any);
+  let model: Model<any>;
+  if (config.provider === "openai-compatible") {
+    model = buildOpenAiCompatModel(config);
+    log.info(`[stavrobot] createAgent: using openai-compatible model "${model.id}" via ${config.baseUrl}`);
+  } else {
+    model = getModel(config.provider as any, config.model as any);
+    if (model === undefined) {
+      throw new Error(`No model available for provider "${config.provider}".`);
+    }
+  }
   const tools = [createExecuteSqlTool(pool), createManageKnowledgeTool(pool), createSendSignalMessageTool(pool, config), createManageCronTool(pool), createRunPythonTool(), createManagePagesTool(pool), createManageUploadsTool(), createSearchTool(pool, config.embeddings), createManageFilesTool(), createManageInterlocutorsTool(pool), createManageAgentsTool(pool), createSendAgentMessageTool(pool, () => currentAgentId)];
   tools.push(
     createManagePluginsTool({ coderEnabled: config.coder !== undefined }),

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -141,3 +141,123 @@ name = "Stavros"
     expect(config.compactionTokenThreshold).toBe(50000);
   });
 });
+
+describe("loadConfig openai-compatible provider validation", () => {
+  it("throws when provider is openai-compatible and baseUrl is missing", async () => {
+    const toml = `
+provider = "openai-compatible"
+model = "claude-sonnet-4-6"
+apiKey = "test-key"
+publicHostname = "https://example.com"
+
+[owner]
+name = "Stavros"
+`;
+    setupMocks(toml);
+    const { loadConfig } = await import("./config.js");
+    expect(() => loadConfig()).toThrow("Config must specify baseUrl when provider is \"openai-compatible\".");
+  });
+
+  it("throws when baseUrl is set for a non-openai-compatible provider", async () => {
+    const toml = `
+provider = "anthropic"
+model = "claude-sonnet-4-20250514"
+apiKey = "test-key"
+baseUrl = "http://localhost:8317/v1"
+publicHostname = "https://example.com"
+
+[owner]
+name = "Stavros"
+`;
+    setupMocks(toml);
+    const { loadConfig } = await import("./config.js");
+    expect(() => loadConfig()).toThrow("Config baseUrl is only valid when provider is \"openai-compatible\".");
+  });
+
+  it("loads successfully for openai-compatible provider with baseUrl", async () => {
+    const toml = `
+provider = "openai-compatible"
+model = "claude-sonnet-4-6"
+apiKey = "test-key"
+baseUrl = "http://localhost:8317/v1"
+publicHostname = "https://example.com"
+
+[owner]
+name = "Stavros"
+`;
+    setupMocks(toml);
+    const { loadConfig } = await import("./config.js");
+    const config = loadConfig();
+    expect(config.baseUrl).toBe("http://localhost:8317/v1");
+    expect(config.contextWindow).toBeUndefined();
+    expect(config.maxTokens).toBeUndefined();
+  });
+
+  it("throws when baseUrl is empty for openai-compatible provider", async () => {
+    const toml = `
+provider = "openai-compatible"
+model = "claude-sonnet-4-6"
+apiKey = "test-key"
+baseUrl = ""
+publicHostname = "https://example.com"
+
+[owner]
+name = "Stavros"
+`;
+    setupMocks(toml);
+    const { loadConfig } = await import("./config.js");
+    expect(() => loadConfig()).toThrow("Config baseUrl must not be empty.");
+  });
+
+  it("throws when baseUrl is whitespace-only for openai-compatible provider", async () => {
+    const toml = `
+provider = "openai-compatible"
+model = "claude-sonnet-4-6"
+apiKey = "test-key"
+baseUrl = "   "
+publicHostname = "https://example.com"
+
+[owner]
+name = "Stavros"
+`;
+    setupMocks(toml);
+    const { loadConfig } = await import("./config.js");
+    expect(() => loadConfig()).toThrow("Config baseUrl must not be empty.");
+  });
+
+  it("throws when baseUrl does not start with http:// or https://", async () => {
+    const toml = `
+provider = "openai-compatible"
+model = "claude-sonnet-4-6"
+apiKey = "test-key"
+baseUrl = "localhost:8317/v1"
+publicHostname = "https://example.com"
+
+[owner]
+name = "Stavros"
+`;
+    setupMocks(toml);
+    const { loadConfig } = await import("./config.js");
+    expect(() => loadConfig()).toThrow("Config baseUrl must start with http:// or https://.");
+  });
+
+  it("loads contextWindow and maxTokens overrides when set", async () => {
+    const toml = `
+provider = "openai-compatible"
+model = "claude-sonnet-4-6"
+apiKey = "test-key"
+baseUrl = "http://localhost:8317/v1"
+contextWindow = 200000
+maxTokens = 64000
+publicHostname = "https://example.com"
+
+[owner]
+name = "Stavros"
+`;
+    setupMocks(toml);
+    const { loadConfig } = await import("./config.js");
+    const config = loadConfig();
+    expect(config.contextWindow).toBe(200000);
+    expect(config.maxTokens).toBe(64000);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,9 @@ export interface Config {
   model: string;
   apiKey?: string;
   authFile?: string;
+  baseUrl?: string;
+  contextWindow?: number;
+  maxTokens?: number;
   publicHostname: string;
   password?: string;
   baseSystemPrompt: string;
@@ -114,6 +117,21 @@ export function loadConfig(): Config {
   }
   if (config.publicHostname.endsWith("/")) {
     throw new Error("Config publicHostname must not end with a trailing slash.");
+  }
+
+  if (config.provider === "openai-compatible" && config.baseUrl === undefined) {
+    throw new Error("Config must specify baseUrl when provider is \"openai-compatible\".");
+  }
+  if (config.provider === "openai-compatible" && config.baseUrl !== undefined) {
+    if (config.baseUrl.trim() === "") {
+      throw new Error("Config baseUrl must not be empty.");
+    }
+    if (!config.baseUrl.startsWith("http://") && !config.baseUrl.startsWith("https://")) {
+      throw new Error("Config baseUrl must start with http:// or https://.");
+    }
+  }
+  if (config.provider !== "openai-compatible" && config.baseUrl !== undefined) {
+    throw new Error("Config baseUrl is only valid when provider is \"openai-compatible\".");
   }
 
   if (config.owner === undefined) {


### PR DESCRIPTION
This enables stavrobot to be used with all openai compatible models. The includes cases where there is a proxy between stavrobot and e.g. anthropic models