### PR TITLE
adding agentmail as inbound channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It has all the nice features of an AI assistant, but focuses on sandboxing, isol
 - **Secure.** Everything runs in a container, your host OS is completely invisible to the AI. The AI doesn't see any secrets unless you want it to.
 - **Light.** Doesn't run one container per component. Plugins all run in a single container, separated by Unix permissions.
 - **Use any model you want.** Local, OpenRouter, Anthropic/OpenAI. Whatever [Pi](https://pi.dev) supports, the bot can use.
-- **Signal/Telegram/WhatsApp/Email integration.** Two-way messaging, with formatting, attachments, etc.
+- **Signal/Telegram/WhatsApp/Email/Agentmail integration.** Two-way messaging, with formatting, attachments, etc.
 - **Three-tier knowledge.** Remembers everything without blowing out its context.  Intelligently and transparently retrieves data from its memory.
 - **Low token usage.** Various optimizations have been made to be light on token usage. It even uses [TOON](https://github.com/toon-format/toon) internally.
 - **Plugins.** Install plugins and extend Stavrobot's capabilities by just giving it a git repo URL. Plugins are isolated from each other — each runs as a dedicated system user with no access to other plugins' files or configuration.
@@ -119,6 +119,14 @@ Email uses a Cloudflare Email Worker for inbound delivery and SMTP for outbound.
 2. Deploy the Cloudflare Email Worker (code in `config.example.toml`) and set the `WEBHOOK_URL` and `WEBHOOK_SECRET` environment variables on the worker.
 3. In Cloudflare Email Routing, add a rule to forward inbound mail to the worker.
 4. Add allowed sender addresses via the `/settings` web UI.
+
+### Agentmail setup
+
+1. Create an account at [agentmail.to](https://agentmail.to) and get an API key.
+2. Create one or more inboxes in the agentmail dashboard.
+3. Add an `[agentmail]` section to your `config.toml` with your API key.
+4. The webhook is registered automatically at `<publicHostname>/agentmail/webhook` on startup.
+5. Add allowed sender addresses via the `/settings` web UI.
 
 ### Running
 
@@ -244,7 +252,7 @@ https://github.com/orgs/stavrobot/repositories
 
 ## Architecture
 
-Three core Docker containers: `app` (TypeScript server, exposes `POST /chat`, handles Telegram webhooks at `POST /telegram/webhook`, handles inbound email webhooks at `POST /email/webhook`, and runs WhatsApp in-process via Baileys), `postgres` (PostgreSQL 17 for persistent state), and `plugin-runner` (Node.js server — lists, inspects, and executes plugins, both locally created and git-installed). An optional `coder` container (Claude Code headless agent for creating and modifying editable plugins) is enabled via the `coder` Docker Compose profile. The main agent can create subagents, each with their own conversation history, system prompt, and tool whitelist. Interlocutors are contact records assigned to agents for inbound message routing.
+Three core Docker containers: `app` (TypeScript server, exposes `POST /chat`, handles Telegram webhooks at `POST /telegram/webhook`, handles inbound email webhooks at `POST /email/webhook`, handles agentmail webhooks at `POST /agentmail/webhook`, and runs WhatsApp in-process via Baileys), `postgres` (PostgreSQL 17 for persistent state), and `plugin-runner` (Node.js server — lists, inspects, and executes plugins, both locally created and git-installed). An optional `coder` container (Claude Code headless agent for creating and modifying editable plugins) is enabled via the `coder` Docker Compose profile. The main agent can create subagents, each with their own conversation history, system prompt, and tool whitelist. Interlocutors are contact records assigned to agents for inbound message routing.
 
 ## License
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -65,7 +65,7 @@ too formal.
 """
 
 # The owner of this bot. Used to seed the owner interlocutor record on startup.
-# name is required. signal, telegram, whatsapp, and email are the owner's personal
+# name is required. signal, telegram, whatsapp, email, and agentmail are the owner's personal
 # numbers/IDs/addresses — the ones the owner messages the bot from (not the bot's
 # own numbers). Include whichever channels the owner uses.
 [owner]
@@ -76,6 +76,7 @@ name = "Stavros"
 # email = "owner@example.com"          # specific address
 # email = "*@example.com"              # any address at this domain
 # email = "myuser+*@gmail.com"         # any plus-tag for this user
+# agentmail = "owner@example.com"
 
 # Signal integration. account is the bot's phone number (registered with
 # signal-cli — must be a separate number from the owner's).
@@ -151,6 +152,12 @@ botToken = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
 # smtpUser = "bot@example.com"
 # smtpPassword = "your-smtp-password"
 # fromAddress = "bot@example.com"
+
+# Agentmail integration. Provides email inboxes for the agent via the
+# agentmail API. Create an account at https://agentmail.to to get an API key.
+# Inboxes are managed in the agentmail dashboard, not in this file.
+# [agentmail]
+# apiKey = "your-agentmail-api-key"
 
 # Enables the self-programming coder agent. Uses Claude Code headless, which
 # requires subscription auth (see README). The model must be a Claude Code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   app:
     build: .
     ports:
-      - "10568:3000"
+      - "10567:3000"
     environment:
       TZ: ${TZ:-UTC}
       PGHOST: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   app:
     build: .
     ports:
-      - "10567:3000"
+      - "10568:3000"
     environment:
       TZ: ${TZ:-UTC}
       PGHOST: postgres

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,15 @@
         "@toon-format/toon": "^2.1.0",
         "@types/qrcode-terminal": "^0.12.2",
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
+        "agentmail": "^0.4.8",
         "busboy": "^1.6.0",
         "cron-parser": "^5.5.0",
         "mailparser": "^3.9.4",
         "marked": "^17.0.3",
         "nodemailer": "^8.0.2",
         "pg": "^8.11.3",
-        "qrcode-terminal": "^0.12.0"
+        "qrcode-terminal": "^0.12.0",
+        "svix": "^1.88.0"
       },
       "devDependencies": {
         "@types/busboy": "^1.5.4",
@@ -2191,6 +2193,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -2519,6 +2527,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentmail": {
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/agentmail/-/agentmail-0.4.20.tgz",
+      "integrity": "sha512-rw9P3nZxhDC1TwsthsSSMNk354P0xnqBRuAAF3+763RnVek0mKLrAQfJDeZ1r+OVgKSJXOINVrVRcEg7xqnPDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -2898,6 +2918,12 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4145,6 +4171,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -4187,6 +4223,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.99.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.99.1.tgz",
+      "integrity": "sha512-JfpvbAg5iT5NagDAfOq3e6Ci6NbOMbMm6C3DnfDBB60m2JDK+Z2hXPE9XNAmutb53DCdPoih1V70IbklZnX09A==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/thread-stream": {
@@ -4566,9 +4611,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -18,13 +18,15 @@
     "@toon-format/toon": "^2.1.0",
     "@types/qrcode-terminal": "^0.12.2",
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
+    "agentmail": "^0.4.8",
     "busboy": "^1.6.0",
     "cron-parser": "^5.5.0",
     "mailparser": "^3.9.4",
     "marked": "^17.0.3",
     "nodemailer": "^8.0.2",
     "pg": "^8.11.3",
-    "qrcode-terminal": "^0.12.0"
+    "qrcode-terminal": "^0.12.0",
+    "svix": "^1.88.0"
   },
   "devDependencies": {
     "@types/busboy": "^1.5.4",

--- a/src/agent-send-tools.test.ts
+++ b/src/agent-send-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Pool, QueryResult } from "pg";
-import { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool } from "./send-tools.js";
+import { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createDownloadAgentmailAttachmentTool } from "./send-tools.js";
 import type { Config } from "./config.js";
 import { initInternalFetch } from "./internal-fetch.js";
 
@@ -47,10 +47,25 @@ vi.mock("./email-api.js", () => ({
   initializeEmailTransport: vi.fn(),
 }));
 
+// Mock the agentmail-api module so tests can control sendAgentmailMessage and getAgentmailAttachmentUrl.
+vi.mock("./agentmail-api.js", () => ({
+  sendAgentmailMessage: vi.fn(),
+  getAgentmailAttachmentUrl: vi.fn(),
+  initializeAgentmailClient: vi.fn(),
+  registerAgentmailWebhook: vi.fn(),
+}));
+
+// Mock the uploads module so tests can control saveAttachment.
+vi.mock("./uploads.js", () => ({
+  saveAttachment: vi.fn(),
+}));
+
 import { resolveRecipient, resolveInterlocutorByName, getMainAgentId } from "./database.js";
 import { isInAllowlist } from "./allowlist.js";
 import { getWhatsappSocket, sendWhatsappTextMessage } from "./whatsapp-api.js";
 import { sendEmail } from "./email-api.js";
+import { sendAgentmailMessage, getAgentmailAttachmentUrl } from "./agentmail-api.js";
+import { saveAttachment } from "./uploads.js";
 import { setCurrentAgentId } from "./agent-context.js";
 
 function makeText(result: { content: Array<{ type: string; text?: string }> }): string {
@@ -731,5 +746,281 @@ describe("subagent recipient scoping", () => {
     const tool = createSendEmailTool(pool, config);
     const result = await tool.execute("call-1", { recipient: "anyone@example.com", subject: "Hi", message: "hello" });
     expect(makeText(result)).not.toContain("assigned interlocutor");
+  });
+
+  it("allows main agent to send agentmail to any recipient", async () => {
+    // Main agent (ID 1) is exempt from scoping.
+    vi.mocked(resolveRecipient).mockResolvedValue({ identifier: "anyone@example.com" });
+    const pool = makeScopingPool(["assigned@example.com"], "anyone@example.com");
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    vi.mocked(sendAgentmailMessage).mockResolvedValue(undefined);
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "anyone@example.com", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).not.toContain("assigned interlocutor");
+  });
+
+  it("allows subagent to send to its assigned agentmail interlocutor", async () => {
+    setCurrentAgentId(2);
+    vi.mocked(resolveRecipient).mockResolvedValue({ identifier: "assigned@example.com" });
+    const pool = makeScopingPool(["assigned@example.com"], "assigned@example.com");
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    vi.mocked(sendAgentmailMessage).mockResolvedValue(undefined);
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "assigned@example.com", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).not.toContain("assigned interlocutor");
+  });
+
+  it("rejects subagent sending to a different agentmail interlocutor", async () => {
+    setCurrentAgentId(2);
+    vi.mocked(resolveRecipient).mockResolvedValue({ identifier: "other@example.com" });
+    // The scoping pool returns only assigned@example.com as assigned to agent 2.
+    const pool = makeScopingPool(["assigned@example.com"], "other@example.com");
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "other@example.com", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).toContain("assigned interlocutor");
+    expect(makeText(result)).toContain("send_agent_message");
+  });
+});
+
+describe("isInAllowlist (via send tools) — agentmail", () => {
+  it("send_agentmail rejects when recipient is not in allowlist", async () => {
+    vi.mocked(resolveRecipient).mockResolvedValue(null);
+    vi.mocked(resolveInterlocutorByName).mockResolvedValue(null);
+    vi.mocked(isInAllowlist).mockReturnValue(false);
+    const pool = makeIdentityFoundPool("stranger@example.com");
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "stranger@example.com", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).toContain("not in the agentmail allowlist");
+  });
+});
+
+describe("send_agentmail — recipient resolution", () => {
+  it("rejects with a specific error when interlocutor exists but has no agentmail identity", async () => {
+    vi.mocked(resolveRecipient).mockResolvedValue(null);
+    vi.mocked(resolveInterlocutorByName).mockResolvedValue({ id: 5 });
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "Mom", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).toContain("has no agentmail identity");
+    expect(makeText(result)).toContain("manage_interlocutors");
+  });
+
+  it("rejects when display name is not found and raw ID is not in interlocutor_identities", async () => {
+    vi.mocked(resolveRecipient).mockResolvedValue(null);
+    vi.mocked(resolveInterlocutorByName).mockResolvedValue(null);
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "unknown@example.com", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).toContain("unknown recipient");
+    expect(makeText(result)).toContain("unknown@example.com");
+  });
+
+  it("rejects when display name resolves but resolved identifier is not in allowlist", async () => {
+    vi.mocked(resolveRecipient).mockResolvedValue({ identifier: "stranger@example.com" });
+    vi.mocked(isInAllowlist).mockReturnValue(false);
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "Mom", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).toContain("not in the agentmail allowlist");
+  });
+
+  it("rejects with disabled error when resolveRecipient returns disabled", async () => {
+    vi.mocked(resolveRecipient).mockResolvedValue({ disabled: true, displayName: "Mom" });
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "Mom", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).toContain('Interlocutor "Mom" is disabled');
+  });
+
+  it("rejects with unknown recipient when raw email belongs to a disabled interlocutor", async () => {
+    vi.mocked(resolveRecipient).mockResolvedValue(null);
+    vi.mocked(resolveInterlocutorByName).mockResolvedValue(null);
+    // The pool returns no rows because the JOIN filters out disabled interlocutors.
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "disabled@example.com", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).toContain("unknown recipient");
+  });
+
+  it("uses a query that joins interlocutors and checks enabled=true for the agentmail raw-ID path", async () => {
+    vi.mocked(resolveRecipient).mockResolvedValue(null);
+    vi.mocked(resolveInterlocutorByName).mockResolvedValue(null);
+    const { pool, capturedQuery } = makeCapturingPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    await tool.execute("call-1", { recipient: "test@example.com", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(capturedQuery.text).toContain("JOIN interlocutors");
+    expect(capturedQuery.text).toContain("enabled = true");
+    // The shared resolveOutboundRecipient helper uses a parameterized query ($2 for service).
+    expect(capturedQuery.text).toContain("service = $2");
+  });
+
+  it("normalizes recipient email to lowercase before allowlist check", async () => {
+    vi.mocked(resolveRecipient).mockResolvedValue(null);
+    vi.mocked(resolveInterlocutorByName).mockResolvedValue(null);
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+    vi.mocked(sendAgentmailMessage).mockResolvedValue(undefined);
+    const pool = makeIdentityFoundPool("test@example.com");
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    await tool.execute("call-1", { recipient: "TEST@EXAMPLE.COM", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(vi.mocked(isInAllowlist)).toHaveBeenCalledWith("agentmail", "test@example.com");
+  });
+});
+
+describe("send_agentmail — text send", () => {
+  beforeEach(() => {
+    vi.mocked(resolveRecipient).mockResolvedValue({ identifier: "mom@example.com" });
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+    vi.mocked(sendAgentmailMessage).mockResolvedValue(undefined);
+  });
+
+  it("calls sendAgentmailMessage with the resolved recipient, inboxId, subject, and message", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "Mom", inboxId: "inbox-1", subject: "Hello", message: "hi there" });
+    expect(vi.mocked(sendAgentmailMessage)).toHaveBeenCalledWith("inbox-1", "mom@example.com", "Hello", "hi there", undefined);
+    expect(makeText(result)).toBe("Message sent successfully.");
+  });
+
+  it("passes replyToMessageId when provided", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    await tool.execute("call-1", { recipient: "Mom", inboxId: "inbox-1", subject: "Re: Hello", message: "reply body", replyToMessageId: "msg-42" });
+    expect(vi.mocked(sendAgentmailMessage)).toHaveBeenCalledWith("inbox-1", "mom@example.com", "Re: Hello", "reply body", "msg-42");
+  });
+});
+
+describe("send_agentmail — attachment send", () => {
+  beforeEach(() => {
+    vi.mocked(resolveRecipient).mockResolvedValue({ identifier: "mom@example.com" });
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+    vi.mocked(sendAgentmailMessage).mockResolvedValue(undefined);
+  });
+
+  it("returns error when attachmentPath is outside the temp directory", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "Mom", inboxId: "inbox-1", subject: "Hi", message: "hello", attachmentPath: "/etc/passwd" });
+    expect(makeText(result)).toContain("attachmentPath must be under the temporary attachments directory");
+  });
+
+  it("rejects a path that is a sibling directory of TEMP_ATTACHMENTS_DIR (path traversal)", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+    // /tmp/stavrobot-temp-evil/foo starts with /tmp/stavrobot-temp but is not inside it
+    const result = await tool.execute("call-1", { recipient: "Mom", inboxId: "inbox-1", subject: "Hi", message: "hello", attachmentPath: "/tmp/stavrobot-temp-evil/foo.txt" });
+    expect(makeText(result)).toContain("attachmentPath must be under the temporary attachments directory");
+  });
+
+  it("deletes the temp file even when sendAgentmailMessage throws", async () => {
+    vi.mocked(sendAgentmailMessage).mockRejectedValue(new Error("send failed"));
+
+    // We need a real temp file for the tool to read and then delete.
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const filePath = path.join("/tmp/stavrobot-temp", "test-cleanup.txt");
+    await fs.mkdir("/tmp/stavrobot-temp", { recursive: true });
+    await fs.writeFile(filePath, "test content");
+
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createSendAgentmailTool(pool, config);
+
+    await expect(
+      tool.execute("call-1", { recipient: "Mom", inboxId: "inbox-1", subject: "Hi", message: "hello", attachmentPath: filePath }),
+    ).rejects.toThrow("send failed");
+
+    // File must have been deleted despite the error.
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+});
+
+describe("download_agentmail_attachment — happy path", () => {
+  it("fetches the attachment URL, saves it, and returns the stored path and metadata", async () => {
+    vi.mocked(getAgentmailAttachmentUrl).mockResolvedValue({
+      downloadUrl: "https://cdn.example.com/attachment.pdf",
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      size: 1024,
+    });
+
+    const fakeArrayBuffer = new ArrayBuffer(8);
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => fakeArrayBuffer,
+    } as unknown as Response);
+
+    vi.mocked(saveAttachment).mockResolvedValue({
+      storedPath: "/tmp/stavrobot-temp/upload-abc123.pdf",
+      storedFilename: "upload-abc123.pdf",
+    });
+
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createDownloadAgentmailAttachmentTool(pool, config);
+    const result = await tool.execute("call-1", { inboxId: "inbox-1", messageId: "msg-1", attachmentId: "att-1" });
+
+    expect(vi.mocked(getAgentmailAttachmentUrl)).toHaveBeenCalledWith("inbox-1", "msg-1", "att-1");
+    expect(vi.mocked(saveAttachment)).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "report.pdf",
+      "application/pdf",
+    );
+
+    const text = makeText(result);
+    expect(text).toContain("/tmp/stavrobot-temp/upload-abc123.pdf");
+    expect(text).toContain("report.pdf");
+    expect(text).toContain("application/pdf");
+    expect(text).toContain("1024");
+
+    expect(result.details).toMatchObject({
+      storedPath: "/tmp/stavrobot-temp/upload-abc123.pdf",
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      size: 1024,
+    });
+  });
+
+  it("falls back to attachmentId as filename and application/octet-stream when metadata is absent", async () => {
+    vi.mocked(getAgentmailAttachmentUrl).mockResolvedValue({
+      downloadUrl: "https://cdn.example.com/blob",
+      filename: undefined,
+      contentType: undefined,
+      size: 512,
+    });
+
+    const fakeArrayBuffer = new ArrayBuffer(4);
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => fakeArrayBuffer,
+    } as unknown as Response);
+
+    vi.mocked(saveAttachment).mockResolvedValue({
+      storedPath: "/tmp/stavrobot-temp/upload-xyz.bin",
+      storedFilename: "upload-xyz.bin",
+    });
+
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createDownloadAgentmailAttachmentTool(pool, config);
+    await tool.execute("call-1", { inboxId: "inbox-1", messageId: "msg-1", attachmentId: "att-99" });
+
+    expect(vi.mocked(saveAttachment)).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "att-99",
+      "application/octet-stream",
+    );
   });
 });

--- a/src/agent-send-tools.test.ts
+++ b/src/agent-send-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Pool, QueryResult } from "pg";
-import { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createDownloadAgentmailAttachmentTool } from "./send-tools.js";
+import { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createManageAgentmailTool } from "./send-tools.js";
 import type { Config } from "./config.js";
 import { initInternalFetch } from "./internal-fetch.js";
 
@@ -47,10 +47,15 @@ vi.mock("./email-api.js", () => ({
   initializeEmailTransport: vi.fn(),
 }));
 
-// Mock the agentmail-api module so tests can control sendAgentmailMessage and getAgentmailAttachmentUrl.
+// Mock the agentmail-api module so tests can control all agentmail API functions.
 vi.mock("./agentmail-api.js", () => ({
   sendAgentmailMessage: vi.fn(),
   getAgentmailAttachmentUrl: vi.fn(),
+  listAgentmailInboxes: vi.fn(),
+  listAgentmailThreads: vi.fn(),
+  listAgentmailMessages: vi.fn(),
+  getAgentmailMessage: vi.fn(),
+  deleteAgentmailThread: vi.fn(),
   initializeAgentmailClient: vi.fn(),
   registerAgentmailWebhook: vi.fn(),
 }));
@@ -64,7 +69,7 @@ import { resolveRecipient, resolveInterlocutorByName, getMainAgentId } from "./d
 import { isInAllowlist } from "./allowlist.js";
 import { getWhatsappSocket, sendWhatsappTextMessage } from "./whatsapp-api.js";
 import { sendEmail } from "./email-api.js";
-import { sendAgentmailMessage, getAgentmailAttachmentUrl } from "./agentmail-api.js";
+import { sendAgentmailMessage, getAgentmailAttachmentUrl, listAgentmailInboxes, listAgentmailThreads, listAgentmailMessages, getAgentmailMessage, deleteAgentmailThread } from "./agentmail-api.js";
 import { saveAttachment } from "./uploads.js";
 import { setCurrentAgentId } from "./agent-context.js";
 
@@ -781,6 +786,20 @@ describe("subagent recipient scoping", () => {
     expect(makeText(result)).toContain("assigned interlocutor");
     expect(makeText(result)).toContain("send_agent_message");
   });
+
+  it("allows subagent to send agentmail when stored identity has mixed case", async () => {
+    // The stored identity is "Assigned@Example.com" (mixed case) but the recipient
+    // is lowercased to "assigned@example.com" before checkSubagentRecipientScope is called.
+    // Without case normalization for agentmail, the comparison would fail.
+    setCurrentAgentId(2);
+    vi.mocked(resolveRecipient).mockResolvedValue({ identifier: "assigned@example.com" });
+    const pool = makeScopingPool(["Assigned@Example.com"], "assigned@example.com");
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    vi.mocked(sendAgentmailMessage).mockResolvedValue(undefined);
+    const tool = createSendAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { recipient: "assigned@example.com", inboxId: "inbox-1", subject: "Hi", message: "hello" });
+    expect(makeText(result)).not.toContain("assigned interlocutor");
+  });
 });
 
 describe("isInAllowlist (via send tools) — agentmail", () => {
@@ -947,7 +966,217 @@ describe("send_agentmail — attachment send", () => {
   });
 });
 
-describe("download_agentmail_attachment — happy path", () => {
+describe("manage_agentmail — list_inboxes", () => {
+  it("returns formatted inbox list", async () => {
+    vi.mocked(listAgentmailInboxes).mockResolvedValue({
+      count: 2,
+      inboxes: [
+        { inboxId: "inbox-1", email: "bot@example.com", displayName: "Bot Inbox", podId: "pod-1", updatedAt: new Date("2024-01-01"), createdAt: new Date("2024-01-01") },
+        { inboxId: "inbox-2", email: "support@example.com", displayName: undefined, podId: "pod-1", updatedAt: new Date("2024-01-01"), createdAt: new Date("2024-01-01") },
+      ],
+    });
+
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "list_inboxes" });
+
+    const text = makeText(result);
+    expect(text).toContain("Count: 2");
+    expect(text).toContain("inbox-1");
+    expect(text).toContain("bot@example.com");
+    expect(text).toContain("Bot Inbox");
+    expect(text).toContain("inbox-2");
+    expect(text).toContain("support@example.com");
+  });
+});
+
+describe("manage_agentmail — list_threads", () => {
+  it("returns formatted thread list", async () => {
+    vi.mocked(listAgentmailThreads).mockResolvedValue({
+      count: 1,
+      threads: [
+        {
+          inboxId: "inbox-1",
+          threadId: "thread-1",
+          labels: [],
+          timestamp: new Date("2024-06-01T10:00:00Z"),
+          senders: ["alice@example.com"],
+          recipients: ["bot@example.com"],
+          subject: "Hello",
+          preview: "Hi there, how are you?",
+          messageCount: 2,
+          size: 1024,
+          lastMessageId: "msg-2",
+          updatedAt: new Date("2024-06-01"),
+          createdAt: new Date("2024-06-01"),
+        },
+      ],
+    });
+
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "list_threads", inboxId: "inbox-1" });
+
+    expect(vi.mocked(listAgentmailThreads)).toHaveBeenCalledWith("inbox-1", { limit: undefined, pageToken: undefined });
+    const text = makeText(result);
+    expect(text).toContain("Count: 1");
+    expect(text).toContain("thread-1");
+    expect(text).toContain("Hello");
+    expect(text).toContain("alice@example.com");
+    expect(text).toContain("2");
+  });
+
+  it("returns error when inboxId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "list_threads" });
+    expect(makeText(result)).toContain("inboxId is required");
+  });
+});
+
+describe("manage_agentmail — list_messages", () => {
+  it("returns formatted message list", async () => {
+    vi.mocked(listAgentmailMessages).mockResolvedValue({
+      count: 1,
+      messages: [
+        {
+          inboxId: "inbox-1",
+          threadId: "thread-1",
+          messageId: "msg-1",
+          labels: [],
+          timestamp: new Date("2024-06-01T10:00:00Z"),
+          from: "alice@example.com",
+          to: ["bot@example.com"],
+          subject: "Hello",
+          preview: "Hi there",
+          attachments: [{ attachmentId: "att-1", size: 512 }],
+          size: 1024,
+          updatedAt: new Date("2024-06-01"),
+          createdAt: new Date("2024-06-01"),
+        },
+      ],
+    });
+
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "list_messages", inboxId: "inbox-1" });
+
+    expect(vi.mocked(listAgentmailMessages)).toHaveBeenCalledWith("inbox-1", { limit: undefined, pageToken: undefined });
+    const text = makeText(result);
+    expect(text).toContain("Count: 1");
+    expect(text).toContain("msg-1");
+    expect(text).toContain("alice@example.com");
+    expect(text).toContain("Hello");
+    expect(text).toContain("Attachments: 1");
+  });
+
+  it("returns error when inboxId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "list_messages" });
+    expect(makeText(result)).toContain("inboxId is required");
+  });
+});
+
+describe("manage_agentmail — get_message", () => {
+  it("returns full message details including text and html content", async () => {
+    vi.mocked(getAgentmailMessage).mockResolvedValue({
+      inboxId: "inbox-1",
+      threadId: "thread-1",
+      messageId: "msg-1",
+      labels: [],
+      timestamp: new Date("2024-06-01T10:00:00Z"),
+      from: "alice@example.com",
+      to: ["bot@example.com"],
+      cc: ["cc@example.com"],
+      subject: "Hello",
+      extractedText: "Hi there, this is the extracted text.",
+      extractedHtml: "<p>Hi there</p>",
+      text: "Full text body",
+      html: "<p>Full HTML body</p>",
+      attachments: [
+        { attachmentId: "att-1", filename: "report.pdf", contentType: "application/pdf", size: 1024 },
+      ],
+      size: 2048,
+      updatedAt: new Date("2024-06-01"),
+      createdAt: new Date("2024-06-01"),
+    });
+
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "get_message", inboxId: "inbox-1", messageId: "msg-1" });
+
+    expect(vi.mocked(getAgentmailMessage)).toHaveBeenCalledWith("inbox-1", "msg-1");
+    const text = makeText(result);
+    expect(text).toContain("alice@example.com");
+    expect(text).toContain("bot@example.com");
+    expect(text).toContain("cc@example.com");
+    expect(text).toContain("Hello");
+    // Should prefer extractedText over text
+    expect(text).toContain("Hi there, this is the extracted text.");
+    expect(text).not.toContain("Full text body");
+    // Should prefer extractedHtml over html
+    expect(text).toContain("<p>Hi there</p>");
+    expect(text).not.toContain("<p>Full HTML body</p>");
+    expect(text).toContain("att-1");
+    expect(text).toContain("report.pdf");
+  });
+
+  it("returns error when inboxId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "get_message", messageId: "msg-1" });
+    expect(makeText(result)).toContain("inboxId is required");
+  });
+
+  it("returns error when messageId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "get_message", inboxId: "inbox-1" });
+    expect(makeText(result)).toContain("messageId is required");
+  });
+});
+
+describe("manage_agentmail — delete_thread", () => {
+  it("deletes the thread and returns success message", async () => {
+    vi.mocked(deleteAgentmailThread).mockResolvedValue(undefined);
+
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "delete_thread", inboxId: "inbox-1", threadId: "thread-1" });
+
+    expect(vi.mocked(deleteAgentmailThread)).toHaveBeenCalledWith("inbox-1", "thread-1");
+    expect(makeText(result)).toContain("thread-1");
+    expect(makeText(result)).toContain("deleted");
+  });
+
+  it("returns error when inboxId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "delete_thread", threadId: "thread-1" });
+    expect(makeText(result)).toContain("inboxId is required");
+  });
+
+  it("returns error when threadId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "delete_thread", inboxId: "inbox-1" });
+    expect(makeText(result)).toContain("threadId is required");
+  });
+});
+
+describe("manage_agentmail — download_attachment", () => {
   it("fetches the attachment URL, saves it, and returns the stored path and metadata", async () => {
     vi.mocked(getAgentmailAttachmentUrl).mockResolvedValue({
       downloadUrl: "https://cdn.example.com/attachment.pdf",
@@ -969,8 +1198,8 @@ describe("download_agentmail_attachment — happy path", () => {
 
     const pool = makeEmptyPool();
     const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
-    const tool = createDownloadAgentmailAttachmentTool(pool, config);
-    const result = await tool.execute("call-1", { inboxId: "inbox-1", messageId: "msg-1", attachmentId: "att-1" });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "download_attachment", inboxId: "inbox-1", messageId: "msg-1", attachmentId: "att-1" });
 
     expect(vi.mocked(getAgentmailAttachmentUrl)).toHaveBeenCalledWith("inbox-1", "msg-1", "att-1");
     expect(vi.mocked(saveAttachment)).toHaveBeenCalledWith(
@@ -1014,13 +1243,37 @@ describe("download_agentmail_attachment — happy path", () => {
 
     const pool = makeEmptyPool();
     const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
-    const tool = createDownloadAgentmailAttachmentTool(pool, config);
-    await tool.execute("call-1", { inboxId: "inbox-1", messageId: "msg-1", attachmentId: "att-99" });
+    const tool = createManageAgentmailTool(pool, config);
+    await tool.execute("call-1", { action: "download_attachment", inboxId: "inbox-1", messageId: "msg-1", attachmentId: "att-99" });
 
     expect(vi.mocked(saveAttachment)).toHaveBeenCalledWith(
       expect.any(Buffer),
       "att-99",
       "application/octet-stream",
     );
+  });
+
+  it("returns error when inboxId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "download_attachment", messageId: "msg-1", attachmentId: "att-1" });
+    expect(makeText(result)).toContain("inboxId is required");
+  });
+
+  it("returns error when messageId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "download_attachment", inboxId: "inbox-1", attachmentId: "att-1" });
+    expect(makeText(result)).toContain("messageId is required");
+  });
+
+  it("returns error when attachmentId is missing", async () => {
+    const pool = makeEmptyPool();
+    const config = makeConfig({ agentmail: { apiKey: "test-agentmail-key" } });
+    const tool = createManageAgentmailTool(pool, config);
+    const result = await tool.execute("call-1", { action: "download_attachment", inboxId: "inbox-1", messageId: "msg-1" });
+    expect(makeText(result)).toContain("attachmentId is required");
   });
 });

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -22,7 +22,7 @@ import { encodeToToon } from "../toon.js";
 import { log } from "../log.js";
 import { AbortError, TurnProgressPersistedError } from "../errors.js";
 import { toolError, toolSuccess } from "../tool-result.js";
-import { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool } from "../send-tools.js";
+import { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createDownloadAgentmailAttachmentTool } from "../send-tools.js";
 import { currentAgentId, setCurrentAgentId } from "../agent-context.js";
 export { currentAgentId } from "../agent-context.js";
 import {
@@ -52,7 +52,7 @@ import {
 } from "./plugins.js";
 export { TEMP_ATTACHMENTS_DIR } from "../temp-dir.js";
 export { AbortError, TurnProgressPersistedError } from "../errors.js";
-export { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool } from "../send-tools.js";
+export { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createDownloadAgentmailAttachmentTool } from "../send-tools.js";
 
 // Re-export everything from the extracted modules so external importers that
 // import from "./agent.js" continue to work without changes.
@@ -466,6 +466,10 @@ export async function createAgent(config: Config, pool: pg.Pool): Promise<Agent>
   }
   if (config.email !== undefined && config.email.smtpHost !== undefined) {
     tools.push(createSendEmailTool(pool, config));
+  }
+  if (config.agentmail !== undefined) {
+    tools.push(createSendAgentmailTool(pool, config));
+    tools.push(createDownloadAgentmailAttachmentTool(pool, config));
   }
 
   const effectiveBasePrompt = (config.customPrompt !== undefined

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -22,7 +22,7 @@ import { encodeToToon } from "../toon.js";
 import { log } from "../log.js";
 import { AbortError, TurnProgressPersistedError } from "../errors.js";
 import { toolError, toolSuccess } from "../tool-result.js";
-import { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createDownloadAgentmailAttachmentTool } from "../send-tools.js";
+import { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createManageAgentmailTool } from "../send-tools.js";
 import { currentAgentId, setCurrentAgentId } from "../agent-context.js";
 export { currentAgentId } from "../agent-context.js";
 import {
@@ -52,7 +52,7 @@ import {
 } from "./plugins.js";
 export { TEMP_ATTACHMENTS_DIR } from "../temp-dir.js";
 export { AbortError, TurnProgressPersistedError } from "../errors.js";
-export { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createDownloadAgentmailAttachmentTool } from "../send-tools.js";
+export { createSendSignalMessageTool, createSendTelegramMessageTool, createSendWhatsappMessageTool, createSendEmailTool, createSendAgentmailTool, createManageAgentmailTool } from "../send-tools.js";
 
 // Re-export everything from the extracted modules so external importers that
 // import from "./agent.js" continue to work without changes.
@@ -469,7 +469,7 @@ export async function createAgent(config: Config, pool: pg.Pool): Promise<Agent>
   }
   if (config.agentmail !== undefined) {
     tools.push(createSendAgentmailTool(pool, config));
-    tools.push(createDownloadAgentmailAttachmentTool(pool, config));
+    tools.push(createManageAgentmailTool(pool, config));
   }
 
   const effectiveBasePrompt = (config.customPrompt !== undefined

--- a/src/agentmail-api.test.ts
+++ b/src/agentmail-api.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockWebhooksList = vi.fn();
+const mockWebhooksGet = vi.fn();
+const mockWebhooksCreate = vi.fn();
+
+vi.mock("agentmail", () => ({
+  AgentMailClient: vi.fn().mockImplementation(() => ({
+    webhooks: {
+      list: mockWebhooksList,
+      get: mockWebhooksGet,
+      create: mockWebhooksCreate,
+    },
+  })),
+}));
+
+import { initializeAgentmailClient, registerAgentmailWebhook } from "./agentmail-api.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  initializeAgentmailClient("test-api-key");
+});
+
+describe("registerAgentmailWebhook", () => {
+  it("creates a new webhook and returns its secret when none exists", async () => {
+    mockWebhooksList.mockResolvedValue({ webhooks: [], nextPageToken: undefined });
+    mockWebhooksCreate.mockResolvedValue({
+      webhookId: "wh_new",
+      url: "https://example.com/agentmail/webhook",
+      secret: "created-secret",
+      enabled: true,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const secret = await registerAgentmailWebhook("https://example.com");
+
+    expect(mockWebhooksCreate).toHaveBeenCalledWith({
+      url: "https://example.com/agentmail/webhook",
+      eventTypes: ["message.received"],
+    });
+    expect(mockWebhooksGet).not.toHaveBeenCalled();
+    expect(secret).toBe("created-secret");
+  });
+
+  it("fetches full webhook details via get() when a matching webhook is found in list()", async () => {
+    mockWebhooksList.mockResolvedValue({
+      webhooks: [
+        {
+          webhookId: "wh_existing",
+          url: "https://example.com/agentmail/webhook",
+          // secret intentionally absent to simulate production list() behaviour
+          enabled: true,
+          updatedAt: new Date(),
+          createdAt: new Date(),
+        },
+      ],
+      nextPageToken: undefined,
+    });
+    mockWebhooksGet.mockResolvedValue({
+      webhookId: "wh_existing",
+      url: "https://example.com/agentmail/webhook",
+      secret: "fetched-secret",
+      enabled: true,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const secret = await registerAgentmailWebhook("https://example.com");
+
+    expect(mockWebhooksGet).toHaveBeenCalledWith("wh_existing");
+    expect(mockWebhooksCreate).not.toHaveBeenCalled();
+    expect(secret).toBe("fetched-secret");
+  });
+
+  it("paginates through all webhooks before checking for a match", async () => {
+    mockWebhooksList
+      .mockResolvedValueOnce({
+        webhooks: [
+          {
+            webhookId: "wh_other",
+            url: "https://other.example.com/agentmail/webhook",
+            secret: "other-secret",
+            enabled: true,
+            updatedAt: new Date(),
+            createdAt: new Date(),
+          },
+        ],
+        nextPageToken: "page2",
+      })
+      .mockResolvedValueOnce({
+        webhooks: [
+          {
+            webhookId: "wh_target",
+            url: "https://example.com/agentmail/webhook",
+            enabled: true,
+            updatedAt: new Date(),
+            createdAt: new Date(),
+          },
+        ],
+        nextPageToken: undefined,
+      });
+    mockWebhooksGet.mockResolvedValue({
+      webhookId: "wh_target",
+      url: "https://example.com/agentmail/webhook",
+      secret: "target-secret",
+      enabled: true,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const secret = await registerAgentmailWebhook("https://example.com");
+
+    expect(mockWebhooksList).toHaveBeenCalledTimes(2);
+    expect(mockWebhooksGet).toHaveBeenCalledWith("wh_target");
+    expect(secret).toBe("target-secret");
+  });
+});

--- a/src/agentmail-api.ts
+++ b/src/agentmail-api.ts
@@ -1,0 +1,119 @@
+import { AgentMailClient } from "agentmail";
+import type { AgentMail } from "agentmail";
+import { log } from "./log.js";
+
+let client: AgentMailClient | undefined;
+
+export function initializeAgentmailClient(apiKey: string): void {
+  log.info("[stavrobot] Initializing AgentMail client");
+  client = new AgentMailClient({ apiKey });
+}
+
+export async function registerAgentmailWebhook(publicHostname: string): Promise<string> {
+  if (client === undefined) {
+    throw new Error("AgentMail client is not initialized");
+  }
+
+  const targetUrl = `${publicHostname}/agentmail/webhook`;
+
+  const allWebhooks: AgentMail.webhooks.Webhook[] = [];
+  let pageToken: string | undefined;
+  do {
+    const page = await client.webhooks.list({ pageToken });
+    allWebhooks.push(...page.webhooks);
+    pageToken = page.nextPageToken;
+  } while (pageToken !== undefined);
+
+  const existing = allWebhooks.find((webhook) => webhook.url === targetUrl);
+
+  if (existing !== undefined) {
+    log.info("[stavrobot] Reusing existing AgentMail webhook:", targetUrl);
+    const full = await client.webhooks.get(existing.webhookId);
+    return full.secret;
+  }
+
+  log.info("[stavrobot] Creating AgentMail webhook:", targetUrl);
+  const created = await client.webhooks.create({
+    url: targetUrl,
+    eventTypes: ["message.received"],
+  });
+
+  return created.secret;
+}
+
+interface OutboundAttachment {
+  filename: string;
+  content: string;
+  contentType: string;
+}
+
+export async function sendAgentmailMessage(
+  inboxId: string,
+  to: string,
+  subject: string,
+  text: string,
+  replyToMessageId?: string,
+  attachments?: OutboundAttachment[],
+): Promise<void> {
+  if (client === undefined) {
+    throw new Error("AgentMail client is not initialized");
+  }
+
+  const html = text
+    .split(/\n\n+/)
+    .map((paragraph) => `<p>${paragraph}</p>`)
+    .join("");
+
+  const sdkAttachments: AgentMail.SendAttachment[] | undefined =
+    attachments !== undefined && attachments.length > 0
+      ? attachments.map((attachment) => ({
+          filename: attachment.filename,
+          content: attachment.content,
+          contentType: attachment.contentType,
+        }))
+      : undefined;
+
+  if (replyToMessageId !== undefined) {
+    log.info("[stavrobot] Replying to AgentMail message:", replyToMessageId, "in inbox:", inboxId);
+    await client.inboxes.messages.reply(inboxId, replyToMessageId, {
+      text,
+      html,
+      attachments: sdkAttachments,
+    });
+  } else {
+    log.info("[stavrobot] Sending AgentMail message to:", to, "from inbox:", inboxId);
+    await client.inboxes.messages.send(inboxId, {
+      to,
+      subject,
+      text,
+      html,
+      attachments: sdkAttachments,
+    });
+  }
+}
+
+interface AttachmentUrlResult {
+  downloadUrl: string;
+  filename: string | undefined;
+  contentType: string | undefined;
+  size: number;
+}
+
+export async function getAgentmailAttachmentUrl(
+  inboxId: string,
+  messageId: string,
+  attachmentId: string,
+): Promise<AttachmentUrlResult> {
+  if (client === undefined) {
+    throw new Error("AgentMail client is not initialized");
+  }
+
+  const response = await client.inboxes.messages.getAttachment(inboxId, messageId, attachmentId);
+
+  return {
+    downloadUrl: response.downloadUrl,
+    filename: response.filename,
+    contentType: response.contentType,
+    size: response.size,
+  };
+}

--- a/src/agentmail-api.ts
+++ b/src/agentmail-api.ts
@@ -117,3 +117,61 @@ export async function getAgentmailAttachmentUrl(
     size: response.size,
   };
 }
+
+export async function listAgentmailInboxes(): Promise<AgentMail.inboxes.ListInboxesResponse> {
+  if (client === undefined) {
+    throw new Error("AgentMail client is not initialized");
+  }
+
+  return await client.inboxes.list();
+}
+
+export async function listAgentmailThreads(
+  inboxId: string,
+  options?: { limit?: number; pageToken?: string },
+): Promise<AgentMail.ListThreadsResponse> {
+  if (client === undefined) {
+    throw new Error("AgentMail client is not initialized");
+  }
+
+  return await client.inboxes.threads.list(inboxId, {
+    limit: options?.limit,
+    pageToken: options?.pageToken,
+  });
+}
+
+export async function listAgentmailMessages(
+  inboxId: string,
+  options?: { limit?: number; pageToken?: string },
+): Promise<AgentMail.ListMessagesResponse> {
+  if (client === undefined) {
+    throw new Error("AgentMail client is not initialized");
+  }
+
+  return await client.inboxes.messages.list(inboxId, {
+    limit: options?.limit,
+    pageToken: options?.pageToken,
+  });
+}
+
+export async function getAgentmailMessage(
+  inboxId: string,
+  messageId: string,
+): Promise<AgentMail.Message> {
+  if (client === undefined) {
+    throw new Error("AgentMail client is not initialized");
+  }
+
+  return await client.inboxes.messages.get(inboxId, messageId);
+}
+
+export async function deleteAgentmailThread(
+  inboxId: string,
+  threadId: string,
+): Promise<void> {
+  if (client === undefined) {
+    throw new Error("AgentMail client is not initialized");
+  }
+
+  await client.inboxes.threads.delete(inboxId, threadId);
+}

--- a/src/agentmail.test.ts
+++ b/src/agentmail.test.ts
@@ -1,0 +1,413 @@
+import http from "http";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("svix", () => ({
+  Webhook: vi.fn().mockImplementation(() => ({
+    verify: vi.fn(),
+  })),
+}));
+
+vi.mock("./queue.js", () => ({
+  enqueueMessage: vi.fn(),
+}));
+
+vi.mock("./allowlist.js", () => ({
+  isInAllowlist: vi.fn(),
+}));
+
+import { Webhook } from "svix";
+import { isInAllowlist } from "./allowlist.js";
+import { enqueueMessage } from "./queue.js";
+import {
+  setAgentmailWebhookSecret,
+  handleAgentmailWebhookRequest,
+  handleAgentmailWebhook,
+} from "./agentmail.js";
+
+interface MockResponse {
+  statusCode: number | undefined;
+  headers: Record<string, string>;
+  body: string | undefined;
+  headersSent: boolean;
+  writeHead(status: number, headers?: Record<string, string>): void;
+  end(body: string): void;
+}
+
+function makeMockResponse(): MockResponse {
+  const response: MockResponse = {
+    statusCode: undefined,
+    headers: {},
+    body: undefined,
+    headersSent: false,
+    writeHead(status: number, headers?: Record<string, string>): void {
+      this.statusCode = status;
+      if (headers) {
+        Object.assign(this.headers, headers);
+      }
+      this.headersSent = true;
+    },
+    end(body: string): void {
+      this.body = body;
+    },
+  };
+  return response;
+}
+
+function makeMockRequest(body: string, headers: Record<string, string> = {}): http.IncomingMessage {
+  const chunks = [Buffer.from(body)];
+  return {
+    headers,
+    [Symbol.asyncIterator]: async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    },
+  } as unknown as http.IncomingMessage;
+}
+
+describe("handleAgentmailWebhookRequest — secret not set", () => {
+  it("returns 401 when webhook secret is not set", async () => {
+    vi.clearAllMocks();
+    setAgentmailWebhookSecret(undefined);
+
+    const request = makeMockRequest("{}", {
+      "svix-id": "id",
+      "svix-timestamp": "ts",
+      "svix-signature": "sig",
+    });
+    const response = makeMockResponse();
+
+    handleAgentmailWebhookRequest(request, response as unknown as http.ServerResponse);
+
+    await vi.waitFor(() => {
+      expect(response.statusCode).toBe(401);
+    });
+
+    const parsed = JSON.parse(response.body!);
+    expect(parsed.error).toBe("Unauthorized");
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setAgentmailWebhookSecret("test-secret");
+});
+
+describe("handleAgentmailWebhookRequest", () => {
+  it("returns 401 when Svix headers are missing", async () => {
+    const request = makeMockRequest("{}");
+    const response = makeMockResponse();
+
+    handleAgentmailWebhookRequest(request, response as unknown as http.ServerResponse);
+
+    await vi.waitFor(() => {
+      expect(response.statusCode).toBe(401);
+    });
+
+    const parsed = JSON.parse(response.body!);
+    expect(parsed.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when Svix signature verification fails", async () => {
+    const mockVerify = vi.fn().mockImplementation(() => {
+      throw new Error("Invalid signature");
+    });
+    vi.mocked(Webhook).mockImplementation(() => ({ verify: mockVerify }) as unknown as InstanceType<typeof Webhook>);
+
+    const request = makeMockRequest("{}", {
+      "svix-id": "msg_123",
+      "svix-timestamp": "1234567890",
+      "svix-signature": "v1,invalid",
+    });
+    const response = makeMockResponse();
+
+    handleAgentmailWebhookRequest(request, response as unknown as http.ServerResponse);
+
+    await vi.waitFor(() => {
+      expect(response.statusCode).toBe(401);
+    });
+
+    const parsed = JSON.parse(response.body!);
+    expect(parsed.error).toBe("Unauthorized");
+  });
+
+  it("returns 200 and ignores non-message.received events", async () => {
+    const mockVerify = vi.fn();
+    vi.mocked(Webhook).mockImplementation(() => ({ verify: mockVerify }) as unknown as InstanceType<typeof Webhook>);
+
+    const payload = JSON.stringify({ event_type: "message.sent" });
+    const request = makeMockRequest(payload, {
+      "svix-id": "msg_123",
+      "svix-timestamp": "1234567890",
+      "svix-signature": "v1,valid",
+    });
+    const response = makeMockResponse();
+
+    handleAgentmailWebhookRequest(request, response as unknown as http.ServerResponse);
+
+    await vi.waitFor(() => {
+      expect(response.statusCode).toBe(200);
+    });
+
+    const parsed = JSON.parse(response.body!);
+    expect(parsed.ok).toBe(true);
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and processes message.received events", async () => {
+    const mockVerify = vi.fn();
+    vi.mocked(Webhook).mockImplementation(() => ({ verify: mockVerify }) as unknown as InstanceType<typeof Webhook>);
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    const payload = JSON.stringify({
+      event_type: "message.received",
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        subject: "Hello",
+        text: "Hi there",
+        attachments: [],
+      },
+    });
+    const request = makeMockRequest(payload, {
+      "svix-id": "msg_123",
+      "svix-timestamp": "1234567890",
+      "svix-signature": "v1,valid",
+    });
+    const response = makeMockResponse();
+
+    handleAgentmailWebhookRequest(request, response as unknown as http.ServerResponse);
+
+    await vi.waitFor(() => {
+      expect(response.statusCode).toBe(200);
+    });
+
+    const parsed = JSON.parse(response.body!);
+    expect(parsed.ok).toBe(true);
+  });
+});
+
+describe("handleAgentmailWebhook", () => {
+  it("parses plain email address from 'from' field", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Hello",
+      },
+    });
+
+    expect(isInAllowlist).toHaveBeenCalledWith("agentmail", "sender@example.com");
+  });
+
+  it("parses display name format 'Display Name <email@example.com>'", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "John Doe <john@example.com>",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Hello",
+      },
+    });
+
+    expect(isInAllowlist).toHaveBeenCalledWith("agentmail", "john@example.com");
+  });
+
+  it("lowercases the email address", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "SENDER@EXAMPLE.COM",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Hello",
+      },
+    });
+
+    expect(isInAllowlist).toHaveBeenCalledWith("agentmail", "sender@example.com");
+  });
+
+  it("returns early without enqueueing when sender is not in allowlist", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(false);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "stranger@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Hello",
+      },
+    });
+
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  it("enqueues message with correct source and sender when allowed", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        subject: "Test Subject",
+        text: "Hello world",
+      },
+    });
+
+    expect(enqueueMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Hello world"),
+      "agentmail",
+      "sender@example.com",
+    );
+  });
+
+  it("formats message with header line, subject, and text body", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        subject: "Test Subject",
+        text: "Hello world",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).toContain("[Inbox: inbox-1 | Thread: thread-1 | Message: msg-1]");
+    expect(formattedMessage).toContain("Subject: Test Subject");
+    expect(formattedMessage).toContain("Hello world");
+  });
+
+  it("omits Subject line when subject is undefined", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Hello world",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).not.toContain("Subject:");
+    expect(formattedMessage).toContain("Hello world");
+  });
+
+  it("omits Subject line when subject is empty string", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        subject: "",
+        text: "Hello world",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).not.toContain("Subject:");
+  });
+
+  it("uses empty string for text when text is undefined", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+      },
+    });
+
+    expect(enqueueMessage).toHaveBeenCalled();
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).toContain("[Inbox: inbox-1 | Thread: thread-1 | Message: msg-1]");
+  });
+
+  it("includes attachments section when attachments are present", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "See attached",
+        attachments: [
+          {
+            attachment_id: "att-1",
+            filename: "document.pdf",
+            size: 12345,
+            content_type: "application/pdf",
+          },
+        ],
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).toContain("Attachments:");
+    expect(formattedMessage).toContain(
+      "- document.pdf (application/pdf, 12345 bytes, attachmentId: att-1)",
+    );
+  });
+
+  it("omits Attachments section when attachments array is empty", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "No attachments",
+        attachments: [],
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).not.toContain("Attachments:");
+  });
+
+  it("omits Attachments section when attachments field is absent", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "No attachments",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).not.toContain("Attachments:");
+  });
+});

--- a/src/agentmail.test.ts
+++ b/src/agentmail.test.ts
@@ -410,4 +410,128 @@ describe("handleAgentmailWebhook", () => {
     const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
     expect(formattedMessage).not.toContain("Attachments:");
   });
+
+  it("appends HTML section when html is present and no extracted_html", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Plain text",
+        html: "<p>HTML content</p>",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).toContain("Plain text");
+    expect(formattedMessage).toContain("--- HTML version ---");
+    expect(formattedMessage).toContain("<p>HTML content</p>");
+  });
+
+  it("prefers extracted_html over html when both are present", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Plain text",
+        html: "<p>Full HTML with quoted history</p>",
+        extracted_html: "<p>Extracted HTML only</p>",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).toContain("<p>Extracted HTML only</p>");
+    expect(formattedMessage).not.toContain("<p>Full HTML with quoted history</p>");
+  });
+
+  it("prefers extracted_text over text when both are present", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Full text with quoted history",
+        extracted_text: "Extracted text only",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).toContain("Extracted text only");
+    expect(formattedMessage).not.toContain("Full text with quoted history");
+  });
+
+  it("includes HTML section when only html is available and no text", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        html: "<p>HTML only email</p>",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).toContain("--- HTML version ---");
+    expect(formattedMessage).toContain("<p>HTML only email</p>");
+  });
+
+  it("omits HTML section when no html fields are present", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "Plain text only",
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    expect(formattedMessage).not.toContain("--- HTML version ---");
+  });
+
+  it("HTML section appears before Attachments section", async () => {
+    vi.mocked(isInAllowlist).mockReturnValue(true);
+
+    await handleAgentmailWebhook({
+      message: {
+        from: "sender@example.com",
+        inbox_id: "inbox-1",
+        thread_id: "thread-1",
+        message_id: "msg-1",
+        text: "See attached",
+        html: "<p>See attached</p>",
+        attachments: [
+          {
+            attachment_id: "att-1",
+            filename: "file.pdf",
+            size: 100,
+            content_type: "application/pdf",
+          },
+        ],
+      },
+    });
+
+    const formattedMessage = vi.mocked(enqueueMessage).mock.calls[0][0] as string;
+    const htmlIndex = formattedMessage.indexOf("--- HTML version ---");
+    const attachmentsIndex = formattedMessage.indexOf("Attachments:");
+    expect(htmlIndex).toBeGreaterThan(-1);
+    expect(attachmentsIndex).toBeGreaterThan(-1);
+    expect(htmlIndex).toBeLessThan(attachmentsIndex);
+  });
 });

--- a/src/agentmail.ts
+++ b/src/agentmail.ts
@@ -1,0 +1,175 @@
+import http from "http";
+import { Webhook } from "svix";
+import { isInAllowlist } from "./allowlist.js";
+import { enqueueMessage } from "./queue.js";
+import { log } from "./log.js";
+
+let webhookSecret: string | undefined;
+
+export function setAgentmailWebhookSecret(secret: string | undefined): void {
+  webhookSecret = secret;
+}
+
+async function readBody(
+  request: http.IncomingMessage,
+  maxBytes: number = 10 * 1024 * 1024,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of request) {
+    totalBytes += (chunk as Buffer).length;
+    if (totalBytes > maxBytes) {
+      request.destroy();
+      throw new Error("Request body too large");
+    }
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function parseEmailAddress(from: string): string {
+  const match = from.match(/<([^>]+)>/);
+  if (match !== null) {
+    return match[1].toLowerCase();
+  }
+  return from.toLowerCase();
+}
+
+interface AgentmailAttachment {
+  attachment_id: string;
+  filename: string;
+  size: number;
+  content_type: string;
+}
+
+export async function handleAgentmailWebhook(payload: unknown): Promise<void> {
+  const payloadObj = payload as Record<string, unknown>;
+  const message = payloadObj.message as Record<string, unknown>;
+
+  const from = message.from as string;
+  const inboxId = message.inbox_id as string;
+  const threadId = message.thread_id as string;
+  const messageId = message.message_id as string;
+  const subject = message.subject as string | undefined;
+  const text = (message.text as string | undefined) ?? "";
+  const rawAttachments = (message.attachments as AgentmailAttachment[] | undefined) ?? [];
+
+  const senderEmail = parseEmailAddress(from);
+
+  log.info("[stavrobot] Agentmail webhook received from:", senderEmail);
+
+  const headerLine = `[Inbox: ${inboxId} | Thread: ${threadId} | Message: ${messageId}]`;
+
+  const lines: string[] = [headerLine];
+
+  if (subject !== undefined && subject !== "") {
+    lines.push(`Subject: ${subject}`);
+  }
+
+  lines.push("");
+  lines.push(text);
+
+  if (rawAttachments.length > 0) {
+    lines.push("");
+    lines.push("Attachments:");
+    for (const attachment of rawAttachments) {
+      lines.push(
+        `- ${attachment.filename} (${attachment.content_type}, ${attachment.size} bytes, attachmentId: ${attachment.attachment_id})`,
+      );
+    }
+  }
+
+  const formattedMessage = lines.join("\n");
+
+  if (!isInAllowlist("agentmail", senderEmail)) {
+    log.info("[stavrobot] Agentmail message from disallowed address:", senderEmail);
+    return;
+  }
+
+  log.info("[stavrobot] Enqueueing agentmail message from:", senderEmail);
+  void enqueueMessage(formattedMessage, "agentmail", senderEmail);
+}
+
+export function handleAgentmailWebhookRequest(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+): void {
+  void (async (): Promise<void> => {
+    try {
+      if (webhookSecret === undefined) {
+        log.warn("[stavrobot] Agentmail webhook secret not set, rejecting request");
+        response.writeHead(401, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
+
+      const svixId = request.headers["svix-id"];
+      const svixTimestamp = request.headers["svix-timestamp"];
+      const svixSignature = request.headers["svix-signature"];
+
+      if (
+        typeof svixId !== "string" ||
+        typeof svixTimestamp !== "string" ||
+        typeof svixSignature !== "string"
+      ) {
+        log.info("[stavrobot] Agentmail webhook rejected: missing Svix headers");
+        response.writeHead(401, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
+
+      const rawBody = await readBody(request);
+
+      const wh = new Webhook(webhookSecret);
+      try {
+        wh.verify(rawBody, {
+          "svix-id": svixId,
+          "svix-timestamp": svixTimestamp,
+          "svix-signature": svixSignature,
+        });
+      } catch {
+        log.info("[stavrobot] Agentmail webhook rejected: invalid Svix signature");
+        response.writeHead(401, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
+
+      let parsedBody: unknown;
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        response.writeHead(400, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: "Invalid JSON" }));
+        return;
+      }
+
+      const eventType = (parsedBody as Record<string, unknown>).event_type;
+      if (eventType !== "message.received") {
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ ok: true }));
+        return;
+      }
+
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+
+      void handleAgentmailWebhook(parsedBody).catch((error: unknown) => {
+        log.error("[stavrobot] Error processing agentmail webhook:", error);
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === "Request body too large") {
+        if (!response.headersSent) {
+          response.writeHead(413, { "Content-Type": "application/json" });
+          response.end(JSON.stringify({ error: "Request body too large" }));
+        }
+        return;
+      }
+      log.error("[stavrobot] Error handling agentmail webhook request:", error);
+      if (!response.headersSent) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        response.writeHead(500, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: errorMessage }));
+      }
+    }
+  })();
+}

--- a/src/agentmail.ts
+++ b/src/agentmail.ts
@@ -51,8 +51,14 @@ export async function handleAgentmailWebhook(payload: unknown): Promise<void> {
   const threadId = message.thread_id as string;
   const messageId = message.message_id as string;
   const subject = message.subject as string | undefined;
-  const text = (message.text as string | undefined) ?? "";
+  const text = message.text as string | undefined;
+  const html = message.html as string | undefined;
+  const extractedText = message.extracted_text as string | undefined;
+  const extractedHtml = message.extracted_html as string | undefined;
   const rawAttachments = (message.attachments as AgentmailAttachment[] | undefined) ?? [];
+
+  const textContent = extractedText ?? text ?? "";
+  const htmlContent = extractedHtml ?? html;
 
   const senderEmail = parseEmailAddress(from);
 
@@ -67,7 +73,13 @@ export async function handleAgentmailWebhook(payload: unknown): Promise<void> {
   }
 
   lines.push("");
-  lines.push(text);
+  lines.push(textContent);
+
+  if (htmlContent !== undefined) {
+    lines.push("");
+    lines.push("--- HTML version ---");
+    lines.push(htmlContent);
+  }
 
   if (rawAttachments.length > 0) {
     lines.push("");

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -16,6 +16,7 @@ const SUBAGENT_TOOL_ALLOWLIST = new Set([
   "send_telegram_message",
   "send_whatsapp_message",
   "send_email",
+  "send_agentmail",
   "manage_files",
   "manage_uploads",
   "run_python",
@@ -33,7 +34,7 @@ help — Show this documentation.
 create — Create a new subagent.
   name (required): A short, descriptive name for the agent.
   system_prompt (required): The agent's specific instructions, context, and constraints. This is appended to the base agent prompt. Write it as if you're briefing a colleague on a task — include what the agent should do, what information it has, and what constraints it must follow.
-  allowed_tools (optional): Whitelist of core tool names the agent may use. Defaults to [] (no tools). Allowed values: send_signal_message, send_telegram_message, send_whatsapp_message, send_email, manage_files, manage_uploads, run_python, db_search. Use dot notation to scope to specific actions: "manage_uploads.read" allows only the read action of that tool. send_agent_message is always available to all agents — do not include it here. If allowed_plugins is non-empty, run_plugin_tool is implicitly available — do not include it here either.
+  allowed_tools (optional): Whitelist of core tool names the agent may use. Defaults to [] (no tools). Allowed values: send_signal_message, send_telegram_message, send_whatsapp_message, send_email, send_agentmail, manage_files, manage_uploads, run_python, db_search. Use dot notation to scope to specific actions: "manage_uploads.read" allows only the read action of that tool. send_agent_message is always available to all agents — do not include it here. If allowed_plugins is non-empty, run_plugin_tool is implicitly available — do not include it here either.
   allowed_plugins (optional): Whitelist of plugins the agent may use. Defaults to [] (no plugins). Use ["*"] to allow all plugins, ["weather"] to allow all tools in the weather plugin, or ["weather.get_forecast"] to allow a specific tool. Empty list or omission means no plugin access. When non-empty, run_plugin_tool is implicitly available.
   Returns the new agent's ID.
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -17,6 +17,7 @@ const SUBAGENT_TOOL_ALLOWLIST = new Set([
   "send_whatsapp_message",
   "send_email",
   "send_agentmail",
+  "manage_agentmail",
   "manage_files",
   "manage_uploads",
   "run_python",
@@ -34,7 +35,7 @@ help — Show this documentation.
 create — Create a new subagent.
   name (required): A short, descriptive name for the agent.
   system_prompt (required): The agent's specific instructions, context, and constraints. This is appended to the base agent prompt. Write it as if you're briefing a colleague on a task — include what the agent should do, what information it has, and what constraints it must follow.
-  allowed_tools (optional): Whitelist of core tool names the agent may use. Defaults to [] (no tools). Allowed values: send_signal_message, send_telegram_message, send_whatsapp_message, send_email, send_agentmail, manage_files, manage_uploads, run_python, db_search. Use dot notation to scope to specific actions: "manage_uploads.read" allows only the read action of that tool. send_agent_message is always available to all agents — do not include it here. If allowed_plugins is non-empty, run_plugin_tool is implicitly available — do not include it here either.
+  allowed_tools (optional): Whitelist of core tool names the agent may use. Defaults to [] (no tools). Allowed values: send_signal_message, send_telegram_message, send_whatsapp_message, send_email, send_agentmail, manage_agentmail, manage_files, manage_uploads, run_python, db_search. Use dot notation to scope to specific actions: "manage_uploads.read" allows only the read action of that tool. send_agent_message is always available to all agents — do not include it here. If allowed_plugins is non-empty, run_plugin_tool is implicitly available — do not include it here either.
   allowed_plugins (optional): Whitelist of plugins the agent may use. Defaults to [] (no plugins). Use ["*"] to allow all plugins, ["weather"] to allow all tools in the weather plugin, or ["weather.get_forecast"] to allow a specific tool. Empty list or omission means no plugin access. When non-empty, run_plugin_tool is implicitly available.
   Returns the new agent's ID.
 

--- a/src/allowlist.test.ts
+++ b/src/allowlist.test.ts
@@ -88,6 +88,22 @@ describe("loadAllowlist — malformed file", () => {
     expect(() => loadAllowlist(makeConfig())).toThrow("'email' must be an array of strings");
   });
 
+  it("throws when agentmail contains non-strings", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [], telegram: [], agentmail: [123] }));
+
+    const { loadAllowlist } = await import("./allowlist.js");
+    expect(() => loadAllowlist(makeConfig())).toThrow("'agentmail' must be an array of strings");
+  });
+
+  it("throws when agentmail is not an array", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [], telegram: [], agentmail: "user@agentmail.io" }));
+
+    const { loadAllowlist } = await import("./allowlist.js");
+    expect(() => loadAllowlist(makeConfig())).toThrow("'agentmail' must be an array of strings");
+  });
+
   it("throws when signal contains non-strings", async () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [123], telegram: [] }));
@@ -368,6 +384,54 @@ describe("loadAllowlist", () => {
     // No write needed since nothing changed.
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
+
+  it("defaults agentmail to [] when field is absent in existing allowlist.json", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: ["+1111111111"], telegram: [42] }));
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist } = await import("./allowlist.js");
+    const allowlist = loadAllowlist(makeConfig());
+
+    expect(allowlist.agentmail).toEqual([]);
+  });
+
+  it("auto-seeds owner agentmail identity when not already present", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist } = await import("./allowlist.js");
+    const config = makeConfig({ owner: { name: "Owner", agentmail: "owner@agentmail.io" } });
+    const allowlist = loadAllowlist(config);
+
+    expect(allowlist.agentmail).toContain("owner@agentmail.io");
+  });
+
+  it("normalizes owner agentmail to lowercase when seeding", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist } = await import("./allowlist.js");
+    const config = makeConfig({ owner: { name: "Owner", agentmail: "Owner@Agentmail.IO" } });
+    const allowlist = loadAllowlist(config);
+
+    expect(allowlist.agentmail).toContain("owner@agentmail.io");
+    expect(allowlist.agentmail).not.toContain("Owner@Agentmail.IO");
+  });
+
+  it("does not duplicate owner agentmail identity when already present in file", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [], telegram: [], agentmail: ["owner@agentmail.io"] }));
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist } = await import("./allowlist.js");
+    const config = makeConfig({ owner: { name: "Owner", agentmail: "owner@agentmail.io" } });
+    const allowlist = loadAllowlist(config);
+
+    expect(allowlist.agentmail.filter((e) => e === "owner@agentmail.io")).toHaveLength(1);
+    // No write needed since nothing changed.
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
 });
 
 describe("getAllowlist", () => {
@@ -411,7 +475,7 @@ describe("saveAllowlist", () => {
     const config = makeConfig();
     loadAllowlist(config);
 
-    const newAllowlist = { signal: ["+5555555555"], telegram: [99], whatsapp: ["+7777777777"], email: [], notes: { "+5555555555": "Test note" } };
+    const newAllowlist = { signal: ["+5555555555"], telegram: [99], whatsapp: ["+7777777777"], email: [], agentmail: [], notes: { "+5555555555": "Test note" } };
     saveAllowlist(newAllowlist);
 
     const written = mockWriteFileSync.mock.calls[0][1] as string;
@@ -428,7 +492,7 @@ describe("saveAllowlist", () => {
     const { loadAllowlist, saveAllowlist } = await import("./allowlist.js");
     loadAllowlist(makeConfig());
 
-    saveAllowlist({ signal: ["+1111111111"], telegram: [], whatsapp: [], email: [], notes: { "+1111111111": "Work" } });
+    saveAllowlist({ signal: ["+1111111111"], telegram: [], whatsapp: [], email: [], agentmail: [], notes: { "+1111111111": "Work" } });
 
     const written = mockWriteFileSync.mock.calls[0][1] as string;
     const parsed = JSON.parse(written);
@@ -639,6 +703,63 @@ describe("isInAllowlist", () => {
 
     expect(isInAllowlist("email", "user@other.com")).toBe(false);
   });
+
+  it("returns true for an agentmail address in the allowlist", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [], telegram: [], agentmail: ["user@agentmail.io"] }));
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist, isInAllowlist } = await import("./allowlist.js");
+    loadAllowlist(makeConfig());
+
+    expect(isInAllowlist("agentmail", "user@agentmail.io")).toBe(true);
+  });
+
+  it("returns false for an agentmail address not in the allowlist", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [], telegram: [], agentmail: ["user@agentmail.io"] }));
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist, isInAllowlist } = await import("./allowlist.js");
+    loadAllowlist(makeConfig());
+
+    expect(isInAllowlist("agentmail", "other@agentmail.io")).toBe(false);
+  });
+
+  it("matches agentmail case-insensitively", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [], telegram: [], agentmail: ["user@agentmail.io"] }));
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist, isInAllowlist } = await import("./allowlist.js");
+    loadAllowlist(makeConfig());
+
+    expect(isInAllowlist("agentmail", "User@Agentmail.IO")).toBe(true);
+  });
+
+  it("returns true for any agentmail identifier when the allowlist contains '*'", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [], telegram: [], agentmail: ["*"] }));
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist, isInAllowlist } = await import("./allowlist.js");
+    loadAllowlist(makeConfig());
+
+    expect(isInAllowlist("agentmail", "anyone@agentmail.io")).toBe(true);
+    expect(isInAllowlist("agentmail", "other@test.org")).toBe(true);
+  });
+
+  it("returns true for an agentmail address matching a domain wildcard pattern", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ signal: [], telegram: [], agentmail: ["*@agentmail.io"] }));
+    mockWriteFileSync.mockImplementation(() => undefined);
+
+    const { loadAllowlist, isInAllowlist } = await import("./allowlist.js");
+    loadAllowlist(makeConfig());
+
+    expect(isInAllowlist("agentmail", "user@agentmail.io")).toBe(true);
+    expect(isInAllowlist("agentmail", "other@agentmail.io")).toBe(true);
+  });
 });
 
 describe("matchesEmailEntry", () => {
@@ -699,6 +820,7 @@ describe("getOwnerIdentities", () => {
     expect(identities.telegram).toEqual([]);
     expect(identities.whatsapp).toEqual([]);
     expect(identities.email).toEqual([]);
+    expect(identities.agentmail).toEqual([]);
   });
 
   it("returns the owner signal number when set", async () => {
@@ -739,5 +861,21 @@ describe("getOwnerIdentities", () => {
     const identities = getOwnerIdentities(config);
 
     expect(identities.email).toEqual(["owner@example.com"]);
+  });
+
+  it("returns the owner agentmail address when set", async () => {
+    const { getOwnerIdentities } = await import("./allowlist.js");
+    const config = makeConfig({ owner: { name: "Owner", agentmail: "owner@agentmail.io" } });
+    const identities = getOwnerIdentities(config);
+
+    expect(identities.agentmail).toEqual(["owner@agentmail.io"]);
+  });
+
+  it("normalizes owner agentmail to lowercase in getOwnerIdentities", async () => {
+    const { getOwnerIdentities } = await import("./allowlist.js");
+    const config = makeConfig({ owner: { name: "Owner", agentmail: "Owner@Agentmail.IO" } });
+    const identities = getOwnerIdentities(config);
+
+    expect(identities.agentmail).toEqual(["owner@agentmail.io"]);
   });
 });

--- a/src/allowlist.ts
+++ b/src/allowlist.ts
@@ -7,12 +7,13 @@ export interface Allowlist {
   telegram: (number | string)[];
   whatsapp: string[];
   email: string[];
+  agentmail: string[];
   notes: Record<string, string>;
 }
 
 const ALLOWLIST_PATH = process.env.ALLOWLIST_PATH ?? "allowlist.json";
 
-let currentAllowlist: Allowlist = { signal: [], telegram: [], whatsapp: [], email: [], notes: {} };
+let currentAllowlist: Allowlist = { signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} };
 
 function validateAllowlist(value: unknown): Allowlist {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -39,6 +40,11 @@ function validateAllowlist(value: unknown): Allowlist {
   if (!Array.isArray(email) || !email.every((item) => typeof item === "string")) {
     throw new Error("allowlist.json: 'email' must be an array of strings");
   }
+  // The agentmail field is optional for the same backward-compat reason as whatsapp.
+  const agentmail = obj.agentmail ?? [];
+  if (!Array.isArray(agentmail) || !agentmail.every((item) => typeof item === "string")) {
+    throw new Error("allowlist.json: 'agentmail' must be an array of strings");
+  }
   // The notes field is optional for the same backward-compat reason as whatsapp.
   const notes = obj.notes ?? {};
   if (typeof notes !== "object" || notes === null || Array.isArray(notes)) {
@@ -53,6 +59,7 @@ function validateAllowlist(value: unknown): Allowlist {
     telegram: obj.telegram as (number | string)[],
     whatsapp: whatsapp as string[],
     email: email as string[],
+    agentmail: agentmail as string[],
     notes: notesObj as Record<string, string>,
   };
 }
@@ -74,7 +81,7 @@ export function loadAllowlist(config: Config): Allowlist {
       );
     }
 
-    currentAllowlist = { signal: migratedSignal, telegram: migratedTelegram, whatsapp: [], email: [], notes: {} };
+    currentAllowlist = { signal: migratedSignal, telegram: migratedTelegram, whatsapp: [], email: [], agentmail: [], notes: {} };
     saveAllowlist(currentAllowlist);
   }
 
@@ -109,6 +116,14 @@ export function loadAllowlist(config: Config): Allowlist {
     }
   }
 
+  if (config.owner.agentmail !== undefined) {
+    const ownerAgentmail = config.owner.agentmail.toLowerCase();
+    if (!currentAllowlist.agentmail.includes(ownerAgentmail)) {
+      currentAllowlist.agentmail.push(ownerAgentmail);
+      changed = true;
+    }
+  }
+
   if (changed) {
     saveAllowlist(currentAllowlist);
   }
@@ -127,6 +142,7 @@ export function getAllowlist(): Allowlist {
     telegram: [...currentAllowlist.telegram],
     whatsapp: [...currentAllowlist.whatsapp],
     email: [...currentAllowlist.email],
+    agentmail: [...currentAllowlist.agentmail],
     notes: { ...currentAllowlist.notes },
   };
 }
@@ -171,10 +187,13 @@ export function isInAllowlist(service: string, identifier: string): boolean {
   if (service === "email") {
     return currentAllowlist.email.some((entry) => matchesEmailEntry(identifier, entry));
   }
+  if (service === "agentmail") {
+    return currentAllowlist.agentmail.some((entry) => matchesEmailEntry(identifier, entry));
+  }
   return false;
 }
 
-export function getOwnerIdentities(config: Config): { signal: string[]; telegram: number[]; whatsapp: string[]; email: string[] } {
+export function getOwnerIdentities(config: Config): { signal: string[]; telegram: number[]; whatsapp: string[]; email: string[]; agentmail: string[] } {
   const signal = config.owner.signal !== undefined ? [config.owner.signal] : [];
   let telegram: number[] = [];
   if (config.owner.telegram !== undefined) {
@@ -185,5 +204,6 @@ export function getOwnerIdentities(config: Config): { signal: string[]; telegram
   }
   const whatsapp = config.owner.whatsapp !== undefined ? [config.owner.whatsapp] : [];
   const email = config.owner.email !== undefined ? [config.owner.email.toLowerCase()] : [];
-  return { signal, telegram, whatsapp, email };
+  const agentmail = config.owner.agentmail !== undefined ? [config.owner.agentmail.toLowerCase()] : [];
+  return { signal, telegram, whatsapp, email, agentmail };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,15 +44,20 @@ export interface EmailConfig {
   webhookSecret: string;
 }
 
+export interface AgentmailConfig {
+  apiKey: string;
+}
+
 export interface OwnerConfig {
   name: string;
   signal?: string;
   telegram?: string;
   whatsapp?: string;
   email?: string;
+  agentmail?: string;
 }
 
-export const OWNER_CHANNELS: (keyof OwnerConfig)[] = ["signal", "telegram", "whatsapp", "email"];
+export const OWNER_CHANNELS: (keyof OwnerConfig)[] = ["signal", "telegram", "whatsapp", "email", "agentmail"];
 
 export interface Config {
   provider: string;
@@ -78,6 +83,7 @@ export interface Config {
   telegram?: TelegramConfig;
   whatsapp?: WhatsappConfig;
   email?: EmailConfig;
+  agentmail?: AgentmailConfig;
   owner: OwnerConfig;
 }
 

--- a/src/database.test.ts
+++ b/src/database.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
 import type { Pool, QueryResult } from "pg";
 
+// Mutable array so individual tests can temporarily add channels (e.g. "agentmail")
+// without affecting the rest of the suite.
+const ownerChannelsMock: string[] = [];
+
 // Mock config and log dependencies so the module loads without real infrastructure.
 vi.mock("./config.js", () => ({
   loadPostgresConfig: vi.fn().mockReturnValue({}),
-  OWNER_CHANNELS: [],
+  get OWNER_CHANNELS() { return ownerChannelsMock; },
 }));
 vi.mock("./log.js", () => ({
   log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -15,7 +19,7 @@ vi.mock("./toon.js", () => ({
 vi.mock("fs");
 
 import fs from "fs";
-import { resolveInterlocutor, seedOwner, seedCronEntries, upsertPage, deletePage, getPageByPath, getPageQueryByPath, readPage, listPageVersions, restorePageVersion, readScratchpad, saveMessage } from "./database.js";
+import { resolveInterlocutor, seedOwner, seedCronEntries, upsertPage, deletePage, getPageByPath, getPageQueryByPath, readPage, listPageVersions, restorePageVersion, readScratchpad, saveMessage, isOwnerIdentity } from "./database.js";
 import type { OwnerConfig } from "./config.js";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 
@@ -915,5 +919,47 @@ describe("saveMessage — returns inserted id", () => {
 
     expect(capturedValues?.[3]).toBe(42);
     expect(capturedValues?.[4]).toBeNull();
+  });
+});
+
+describe("seedOwner — agentmail identity normalization", () => {
+  it("stores agentmail identity lowercased and isOwnerIdentity matches case-insensitively", async () => {
+    // Temporarily add "agentmail" to the mocked OWNER_CHANNELS for this test.
+    ownerChannelsMock.push("agentmail");
+    try {
+      const upsertedIdentities: Array<{ service: string; identifier: string }> = [];
+      const pool = {
+        query: vi.fn().mockImplementation((text: string, values?: unknown[]) => {
+          if (typeof text === "string" && text.includes("INSERT INTO agents")) {
+            return Promise.resolve({ rows: [{ id: 1 }], rowCount: 1 } as unknown as QueryResult);
+          }
+          if (typeof text === "string" && text.includes("SELECT id FROM interlocutors WHERE owner")) {
+            return Promise.resolve({ rows: [{ id: 99 }], rowCount: 1 } as unknown as QueryResult);
+          }
+          if (typeof text === "string" && text.includes("INSERT INTO interlocutor_identities")) {
+            const service = (values as unknown[])[1] as string;
+            const identifier = (values as unknown[])[2] as string;
+            upsertedIdentities.push({ service, identifier });
+          }
+          return Promise.resolve({ rows: [], rowCount: 0 } as unknown as QueryResult);
+        }),
+      } as unknown as Pool;
+
+      const ownerConfig: OwnerConfig = { name: "Test Owner", agentmail: "User@AgentMail.Example.COM" };
+      await seedOwner(pool, ownerConfig);
+
+      // The identity must be stored lowercased.
+      const agentmailIdentity = upsertedIdentities.find((i) => i.service === "agentmail");
+      expect(agentmailIdentity).toBeDefined();
+      expect(agentmailIdentity?.identifier).toBe("user@agentmail.example.com");
+
+      // isOwnerIdentity must match the original mixed-case address.
+      expect(isOwnerIdentity("agentmail", "User@AgentMail.Example.COM")).toBe(true);
+      expect(isOwnerIdentity("agentmail", "user@agentmail.example.com")).toBe(true);
+      expect(isOwnerIdentity("agentmail", "other@example.com")).toBe(false);
+    } finally {
+      // Restore the mocked OWNER_CHANNELS to its original empty state.
+      ownerChannelsMock.length = 0;
+    }
   });
 });

--- a/src/database.ts
+++ b/src/database.ts
@@ -27,6 +27,8 @@ let mainAgentId: number | null = null;
 let ownerIdentitySet: Set<string> = new Set();
 // Owner email patterns (may include wildcards) for use with matchesEmailEntry.
 let ownerEmailEntries: string[] = [];
+// Owner agentmail patterns (may include wildcards) for use with matchesEmailEntry.
+let ownerAgentmailEntries: string[] = [];
 
 export function getOwnerInterlocutorId(): number {
   if (ownerInterlocutorId === null) {
@@ -45,6 +47,9 @@ export function getMainAgentId(): number {
 export function isOwnerIdentity(service: string, identifier: string): boolean {
   if (service === "email") {
     return ownerEmailEntries.some((entry) => matchesEmailEntry(identifier, entry));
+  }
+  if (service === "agentmail") {
+    return ownerAgentmailEntries.some((entry) => matchesEmailEntry(identifier, entry));
   }
   return ownerIdentitySet.has(`${service}:${identifier}`);
 }
@@ -102,7 +107,7 @@ export async function seedOwner(pool: pg.Pool, ownerConfig: OwnerConfig): Promis
   for (const channel of OWNER_CHANNELS) {
     const value = ownerConfig[channel];
     if (value !== undefined) {
-      const identifier = channel === "email" ? value.toLowerCase() : value;
+      const identifier = (channel === "email" || channel === "agentmail") ? value.toLowerCase() : value;
       identities.push({ service: channel, identifier });
     }
   }
@@ -125,6 +130,9 @@ export async function seedOwner(pool: pg.Pool, ownerConfig: OwnerConfig): Promis
   ownerIdentitySet = new Set(identities.map(({ service, identifier }) => `${service}:${identifier}`));
   ownerEmailEntries = identities
     .filter(({ service }) => service === "email")
+    .map(({ identifier }) => identifier);
+  ownerAgentmailEntries = identities
+    .filter(({ service }) => service === "agentmail")
     .map(({ identifier }) => identifier);
 
   return ownerId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,8 @@ import { initializeWhatsApp } from "./whatsapp.js";
 import { serveHomePage } from "./home.js";
 import { handleEmailWebhookRequest } from "./email.js";
 import { initializeEmailTransport } from "./email-api.js";
+import { handleAgentmailWebhookRequest, setAgentmailWebhookSecret } from "./agentmail.js";
+import { initializeAgentmailClient, registerAgentmailWebhook } from "./agentmail-api.js";
 import { log } from "./log.js";
 
 const CSP_HEADER_VALUE =
@@ -60,6 +62,9 @@ function isPublicRoute(method: string, pathname: string): boolean {
     return true;
   }
   if (method === "POST" && pathname === "/email/webhook") {
+    return true;
+  }
+  if (method === "POST" && pathname === "/agentmail/webhook") {
     return true;
   }
   // Pages have per-row auth: the route handler checks is_public and enforces auth itself.
@@ -491,6 +496,12 @@ async function main(): Promise<void> {
     initializeEmailTransport(config.email);
   }
 
+  if (config.agentmail !== undefined) {
+    initializeAgentmailClient(config.agentmail.apiKey);
+    const agentmailWebhookSecret = await registerAgentmailWebhook(config.publicHostname);
+    setAgentmailWebhookSecret(agentmailWebhookSecret);
+  }
+
   const server = http.createServer((request: http.IncomingMessage, response: http.ServerResponse): void => {
     const url = new URL(request.url || "/", `http://${request.headers.host}`);
     const pathname = url.pathname;
@@ -524,6 +535,8 @@ async function main(): Promise<void> {
         response.writeHead(404, { "Content-Type": "application/json" });
         response.end(JSON.stringify({ error: "Not found" }));
       }
+    } else if (request.method === "POST" && pathname === "/agentmail/webhook") {
+      handleAgentmailWebhookRequest(request, response);
     } else if (request.method === "GET" && pathname === "/login") {
       serveLoginPage(response, config);
     } else if (request.method === "GET" && pathname === "/login/events") {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -17,12 +17,12 @@ const RETRY_DELAY_MS = 30_000;
 
 // Sources that require allowlist + interlocutor lookup before routing.
 // All other external sources route directly to the main agent.
-const GATED_SOURCES: string[] = ["signal", "telegram", "whatsapp", "email"];
+const GATED_SOURCES: string[] = ["signal", "telegram", "whatsapp", "email", "agentmail"];
 
 // Channels where the owner interacts in real-time. Used to decide whether an
 // incoming message while the agent is busy should steer the running turn
 // instead of being queued behind it.
-const INTERACTIVE_SOURCES: string[] = ["signal", "telegram", "whatsapp", "email"];
+const INTERACTIVE_SOURCES: string[] = ["signal", "telegram", "whatsapp", "email", "agentmail"];
 
 function isInteractiveOwnerMessage(source: string | undefined, sender: string | undefined): boolean {
   if (source === undefined) {
@@ -248,6 +248,10 @@ async function sendErrorToSource(
     } catch (sendError) {
       log.error(`[stavrobot] Failed to send WhatsApp error notification: ${sendError instanceof Error ? sendError.message : String(sendError)}`);
     }
+  } else if (source === "agentmail" && sender !== undefined) {
+    // Agentmail replies require an inboxId to know which address to send from, which
+    // we don't have in this context, so we can't send an error notification back yet.
+    log.warn("[stavrobot] Cannot send agentmail error notification, no inbox context available.");
   }
 }
 

--- a/src/send-tools.ts
+++ b/src/send-tools.ts
@@ -12,6 +12,8 @@ import { sendTelegramMessage } from "./telegram-api.js";
 import { internalFetch } from "./internal-fetch.js";
 import { getWhatsappSocket, e164ToJid, sendWhatsappTextMessage } from "./whatsapp-api.js";
 import { sendEmail } from "./email-api.js";
+import { sendAgentmailMessage, getAgentmailAttachmentUrl } from "./agentmail-api.js";
+import { saveAttachment } from "./uploads.js";
 import { TEMP_ATTACHMENTS_DIR } from "./temp-dir.js";
 import { log } from "./log.js";
 import { toolError, toolSuccess } from "./tool-result.js";
@@ -556,6 +558,164 @@ export function createSendEmailTool(pool: pg.Pool, config: Config): AgentTool {
       await sendEmail(recipient, subject, message);
 
       return toolSuccess("Email sent successfully.");
+    },
+  };
+}
+
+// A small map of common file extensions to MIME types for agentmail attachments.
+// Falls back to application/octet-stream for unknown types.
+const MIME_TYPE_MAP: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".pdf": "application/pdf",
+  ".txt": "text/plain",
+  ".html": "text/html",
+  ".htm": "text/html",
+  ".csv": "text/csv",
+  ".json": "application/json",
+  ".xml": "application/xml",
+  ".zip": "application/zip",
+  ".mp3": "audio/mpeg",
+  ".mp4": "video/mp4",
+  ".ogg": "audio/ogg",
+  ".wav": "audio/wav",
+};
+
+export function createSendAgentmailTool(pool: pg.Pool, config: Config): AgentTool {
+  return {
+    name: "send_agentmail",
+    label: "Send agentmail",
+    description: "Send an email via AgentMail to a display name or email address. Sends plain text only.",
+    parameters: Type.Object({
+      recipient: Type.String({ description: "Display name of the recipient (e.g., \"Mom\") or email address (e.g., \"mom@example.com\")." }),
+      inboxId: Type.String({ description: "The AgentMail inbox ID to send from." }),
+      subject: Type.String({ description: "Email subject line." }),
+      message: Type.String({ description: "The email body (plain text)." }),
+      replyToMessageId: Type.Optional(Type.String({ description: "If set, sends as a reply to this message ID for threading." })),
+      attachmentPath: Type.Optional(Type.String({ description: "File path to an attachment under the temp directory (e.g., from manage_files write or a plugin tool)." })),
+    }),
+    execute: async (
+      toolCallId: string,
+      params: unknown
+    ): Promise<AgentToolResult<{ message: string }>> => {
+      const raw = params as {
+        recipient: string;
+        inboxId: string;
+        subject: string;
+        message: string;
+        replyToMessageId?: string;
+        attachmentPath?: string;
+      };
+
+      const recipientInput = raw.recipient;
+      const inboxId = raw.inboxId.trim();
+      const subject = raw.subject.trim();
+      const message = raw.message.trim();
+      const replyToMessageId = raw.replyToMessageId?.trim() || undefined;
+      const attachmentPath = raw.attachmentPath?.trim() || undefined;
+
+      const resolution = await resolveOutboundRecipient(pool, recipientInput, "agentmail", "agentmail", "email address", "send_agentmail", (s) => s.toLowerCase());
+      if ("content" in resolution) {
+        return resolution;
+      }
+
+      // Normalize to lowercase before the allowlist check.
+      const recipient = resolution.recipient.toLowerCase();
+
+      const scopeError = await checkSubagentRecipientScope(pool, recipient, "agentmail", "send_agentmail");
+      if (scopeError !== null) {
+        return scopeError;
+      }
+
+      // Hard gate: recipient must be in the allowlist.
+      if (!isInAllowlist("agentmail", recipient)) {
+        const errorMessage = `Error: recipient '${recipient}' is not in the agentmail allowlist.`;
+        log.warn("[stavrobot] send_agentmail rejected:", errorMessage);
+        return toolError(errorMessage);
+      }
+
+      const agentmailPreview = message.slice(0, 200);
+      log.info(`[stavrobot] message out: agentmail - ${recipient} - ${agentmailPreview}`);
+
+      if (attachmentPath !== undefined) {
+        const resolvedAttachmentPath = path.resolve(attachmentPath);
+        if (!resolvedAttachmentPath.startsWith(TEMP_ATTACHMENTS_DIR + "/")) {
+          return toolError("Error: attachmentPath must be under the temporary attachments directory.");
+        }
+
+        const fileBuffer = await fs.readFile(resolvedAttachmentPath);
+        const filename = path.basename(resolvedAttachmentPath);
+        const extension = path.extname(resolvedAttachmentPath).toLowerCase();
+        const contentType = MIME_TYPE_MAP[extension] ?? "application/octet-stream";
+
+        try {
+          await sendAgentmailMessage(inboxId, recipient, subject, message, replyToMessageId, [
+            { filename, content: fileBuffer.toString("base64"), contentType },
+          ]);
+        } finally {
+          // The path check above guarantees this is a temp file, so always delete it.
+          await fs.unlink(resolvedAttachmentPath);
+        }
+
+        return toolSuccess("Message sent successfully.");
+      }
+
+      await sendAgentmailMessage(inboxId, recipient, subject, message, replyToMessageId);
+
+      return toolSuccess("Message sent successfully.");
+    },
+  };
+}
+
+export function createDownloadAgentmailAttachmentTool(pool: pg.Pool, config: Config): AgentTool {
+  return {
+    name: "download_agentmail_attachment",
+    label: "Download agentmail attachment",
+    description: "Download an attachment from an AgentMail message and save it to the temp directory.",
+    parameters: Type.Object({
+      inboxId: Type.String({ description: "The inbox that received the message." }),
+      messageId: Type.String({ description: "The message containing the attachment." }),
+      attachmentId: Type.String({ description: "The specific attachment to download." }),
+    }),
+    execute: async (
+      toolCallId: string,
+      params: unknown
+    ): Promise<AgentToolResult<{ storedPath: string; filename: string; contentType: string; size: number }>> => {
+      const raw = params as {
+        inboxId: string;
+        messageId: string;
+        attachmentId: string;
+      };
+
+      const { inboxId, messageId, attachmentId } = raw;
+
+      const attachmentInfo = await getAgentmailAttachmentUrl(inboxId, messageId, attachmentId);
+      const { downloadUrl, filename: originalFilename, contentType: originalContentType, size } = attachmentInfo;
+
+      const response = await fetch(downloadUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to download attachment: HTTP ${response.status}`);
+      }
+
+      const filename = originalFilename ?? attachmentId;
+      const contentType = originalContentType ?? "application/octet-stream";
+
+      const { storedPath } = await saveAttachment(
+        Buffer.from(await response.arrayBuffer()),
+        filename,
+        contentType,
+      );
+
+      log.info(`[stavrobot] download_agentmail_attachment: saved ${filename} (${contentType}, ${size} bytes) to ${storedPath}`);
+
+      const resultText = `Attachment saved.\nPath: ${storedPath}\nFilename: ${filename}\nContent type: ${contentType}\nSize: ${size} bytes`;
+      return {
+        content: [{ type: "text" as const, text: resultText }],
+        details: { storedPath, filename, contentType, size },
+      };
     },
   };
 }

--- a/src/send-tools.ts
+++ b/src/send-tools.ts
@@ -12,7 +12,7 @@ import { sendTelegramMessage } from "./telegram-api.js";
 import { internalFetch } from "./internal-fetch.js";
 import { getWhatsappSocket, e164ToJid, sendWhatsappTextMessage } from "./whatsapp-api.js";
 import { sendEmail } from "./email-api.js";
-import { sendAgentmailMessage, getAgentmailAttachmentUrl } from "./agentmail-api.js";
+import { sendAgentmailMessage, getAgentmailAttachmentUrl, listAgentmailInboxes, listAgentmailThreads, listAgentmailMessages, getAgentmailMessage, deleteAgentmailThread } from "./agentmail-api.js";
 import { saveAttachment } from "./uploads.js";
 import { TEMP_ATTACHMENTS_DIR } from "./temp-dir.js";
 import { log } from "./log.js";
@@ -97,10 +97,10 @@ async function checkSubagentRecipientScope(
     [currentAgentId, serviceKey],
   );
 
-  // Email identities are stored as-is (add_identity does not lowercase them),
+  // Email and agentmail identities are stored as-is (add_identity does not lowercase them),
   // but the recipient has already been lowercased by the time we get here.
-  // Normalize both sides for email so the comparison is case-insensitive.
-  const normalize = serviceKey === "email" ? (s: string) => s.toLowerCase() : (s: string) => s;
+  // Normalize both sides for email and agentmail so the comparison is case-insensitive.
+  const normalize = serviceKey === "email" || serviceKey === "agentmail" ? (s: string) => s.toLowerCase() : (s: string) => s;
   const assignedIdentifiers = result.rows.map((row) => normalize(row.identifier));
   if (!assignedIdentifiers.includes(normalize(recipient))) {
     const errorMessage = `You can only message your assigned interlocutor. If you need to message someone else, ask the main agent (agent ${getMainAgentId()}) via send_agent_message.`;
@@ -670,52 +670,192 @@ export function createSendAgentmailTool(pool: pg.Pool, config: Config): AgentToo
   };
 }
 
-export function createDownloadAgentmailAttachmentTool(pool: pg.Pool, config: Config): AgentTool {
+export function createManageAgentmailTool(pool: pg.Pool, config: Config): AgentTool {
   return {
-    name: "download_agentmail_attachment",
-    label: "Download agentmail attachment",
-    description: "Download an attachment from an AgentMail message and save it to the temp directory.",
+    name: "manage_agentmail",
+    label: "Manage agentmail",
+    description: "Manage AgentMail inboxes — list inboxes, browse threads and messages, download attachments, and delete threads.",
     parameters: Type.Object({
-      inboxId: Type.String({ description: "The inbox that received the message." }),
-      messageId: Type.String({ description: "The message containing the attachment." }),
-      attachmentId: Type.String({ description: "The specific attachment to download." }),
+      action: Type.Union([
+        Type.Literal("list_inboxes"),
+        Type.Literal("list_threads"),
+        Type.Literal("list_messages"),
+        Type.Literal("get_message"),
+        Type.Literal("delete_thread"),
+        Type.Literal("download_attachment"),
+      ], { description: "Action to perform: list_inboxes, list_threads, list_messages, get_message, delete_thread, or download_attachment." }),
+      inboxId: Type.Optional(Type.String({ description: "The inbox ID. Required for all actions except list_inboxes." })),
+      threadId: Type.Optional(Type.String({ description: "The thread ID. Required for delete_thread." })),
+      messageId: Type.Optional(Type.String({ description: "The message ID. Required for get_message and download_attachment." })),
+      attachmentId: Type.Optional(Type.String({ description: "The attachment ID. Required for download_attachment." })),
+      limit: Type.Optional(Type.Number({ description: "Maximum number of results to return. For list_threads and list_messages." })),
+      pageToken: Type.Optional(Type.String({ description: "Pagination token for list_threads and list_messages." })),
     }),
     execute: async (
       toolCallId: string,
       params: unknown
-    ): Promise<AgentToolResult<{ storedPath: string; filename: string; contentType: string; size: number }>> => {
+    ): Promise<AgentToolResult<{ message: string } | { storedPath: string; filename: string; contentType: string; size: number }>> => {
       const raw = params as {
-        inboxId: string;
-        messageId: string;
-        attachmentId: string;
+        action: string;
+        inboxId?: string;
+        threadId?: string;
+        messageId?: string;
+        attachmentId?: string;
+        limit?: number;
+        pageToken?: string;
       };
 
-      const { inboxId, messageId, attachmentId } = raw;
+      const { action } = raw;
 
-      const attachmentInfo = await getAgentmailAttachmentUrl(inboxId, messageId, attachmentId);
-      const { downloadUrl, filename: originalFilename, contentType: originalContentType, size } = attachmentInfo;
-
-      const response = await fetch(downloadUrl);
-      if (!response.ok) {
-        throw new Error(`Failed to download attachment: HTTP ${response.status}`);
+      if (action === "list_inboxes") {
+        log.info("[stavrobot] manage_agentmail: listing inboxes");
+        const response = await listAgentmailInboxes();
+        const lines: string[] = [`Count: ${response.count}`];
+        for (const inbox of response.inboxes) {
+          const displayName = inbox.displayName !== undefined ? ` - ${inbox.displayName}` : "";
+          lines.push(`${inbox.inboxId} (${inbox.email})${displayName}`);
+        }
+        if (response.nextPageToken !== undefined) {
+          lines.push(`Next page token: ${response.nextPageToken}`);
+        }
+        return toolSuccess(lines.join("\n"));
       }
 
-      const filename = originalFilename ?? attachmentId;
-      const contentType = originalContentType ?? "application/octet-stream";
+      if (action === "list_threads") {
+        if (raw.inboxId === undefined || raw.inboxId.trim() === "") {
+          return toolError("Error: inboxId is required for list_threads.");
+        }
+        const inboxId = raw.inboxId.trim();
+        log.info("[stavrobot] manage_agentmail: listing threads for inbox:", inboxId);
+        const response = await listAgentmailThreads(inboxId, { limit: raw.limit, pageToken: raw.pageToken });
+        const lines: string[] = [`Count: ${response.count}`];
+        for (const thread of response.threads) {
+          const subject = thread.subject ?? "(no subject)";
+          const senders = thread.senders.join(", ");
+          const preview = thread.preview !== undefined ? ` | Preview: ${thread.preview.slice(0, 100)}` : "";
+          lines.push(`Thread: ${thread.threadId} | Subject: ${subject} | Senders: ${senders} | Messages: ${thread.messageCount} | Timestamp: ${thread.timestamp.toISOString()}${preview}`);
+        }
+        if (response.nextPageToken !== undefined) {
+          lines.push(`Next page token: ${response.nextPageToken}`);
+        }
+        return toolSuccess(lines.join("\n"));
+      }
 
-      const { storedPath } = await saveAttachment(
-        Buffer.from(await response.arrayBuffer()),
-        filename,
-        contentType,
-      );
+      if (action === "list_messages") {
+        if (raw.inboxId === undefined || raw.inboxId.trim() === "") {
+          return toolError("Error: inboxId is required for list_messages.");
+        }
+        const inboxId = raw.inboxId.trim();
+        log.info("[stavrobot] manage_agentmail: listing messages for inbox:", inboxId);
+        const response = await listAgentmailMessages(inboxId, { limit: raw.limit, pageToken: raw.pageToken });
+        const lines: string[] = [`Count: ${response.count}`];
+        for (const message of response.messages) {
+          const subject = message.subject ?? "(no subject)";
+          const preview = message.preview !== undefined ? ` | Preview: ${message.preview.slice(0, 100)}` : "";
+          const attachmentCount = message.attachments !== undefined ? message.attachments.length : 0;
+          lines.push(`Message: ${message.messageId} | From: ${message.from} | Subject: ${subject} | Timestamp: ${message.timestamp.toISOString()} | Attachments: ${attachmentCount}${preview}`);
+        }
+        if (response.nextPageToken !== undefined) {
+          lines.push(`Next page token: ${response.nextPageToken}`);
+        }
+        return toolSuccess(lines.join("\n"));
+      }
 
-      log.info(`[stavrobot] download_agentmail_attachment: saved ${filename} (${contentType}, ${size} bytes) to ${storedPath}`);
+      if (action === "get_message") {
+        if (raw.inboxId === undefined || raw.inboxId.trim() === "") {
+          return toolError("Error: inboxId is required for get_message.");
+        }
+        if (raw.messageId === undefined || raw.messageId.trim() === "") {
+          return toolError("Error: messageId is required for get_message.");
+        }
+        const inboxId = raw.inboxId.trim();
+        const messageId = raw.messageId.trim();
+        log.info("[stavrobot] manage_agentmail: getting message:", messageId, "from inbox:", inboxId);
+        const message = await getAgentmailMessage(inboxId, messageId);
+        const lines: string[] = [
+          `Message ID: ${message.messageId}`,
+          `From: ${message.from}`,
+          `To: ${message.to.join(", ")}`,
+        ];
+        if (message.cc !== undefined && message.cc.length > 0) {
+          lines.push(`CC: ${message.cc.join(", ")}`);
+        }
+        lines.push(`Subject: ${message.subject ?? "(no subject)"}`);
+        lines.push(`Timestamp: ${message.timestamp.toISOString()}`);
+        const textContent = message.extractedText ?? message.text;
+        if (textContent !== undefined) {
+          lines.push(`\nText content:\n${textContent}`);
+        }
+        const htmlContent = message.extractedHtml ?? message.html;
+        if (htmlContent !== undefined) {
+          lines.push(`\nHTML content:\n${htmlContent}`);
+        }
+        if (message.attachments !== undefined && message.attachments.length > 0) {
+          lines.push(`\nAttachments:`);
+          for (const attachment of message.attachments) {
+            const filename = attachment.filename ?? "(no filename)";
+            const contentType = attachment.contentType ?? "unknown";
+            lines.push(`  ${attachment.attachmentId} | ${filename} | ${contentType} | ${attachment.size} bytes`);
+          }
+        }
+        return toolSuccess(lines.join("\n"));
+      }
 
-      const resultText = `Attachment saved.\nPath: ${storedPath}\nFilename: ${filename}\nContent type: ${contentType}\nSize: ${size} bytes`;
-      return {
-        content: [{ type: "text" as const, text: resultText }],
-        details: { storedPath, filename, contentType, size },
-      };
+      if (action === "delete_thread") {
+        if (raw.inboxId === undefined || raw.inboxId.trim() === "") {
+          return toolError("Error: inboxId is required for delete_thread.");
+        }
+        if (raw.threadId === undefined || raw.threadId.trim() === "") {
+          return toolError("Error: threadId is required for delete_thread.");
+        }
+        const inboxId = raw.inboxId.trim();
+        const threadId = raw.threadId.trim();
+        log.info("[stavrobot] manage_agentmail: deleting thread:", threadId, "from inbox:", inboxId);
+        await deleteAgentmailThread(inboxId, threadId);
+        return toolSuccess(`Thread ${threadId} deleted.`);
+      }
+
+      if (action === "download_attachment") {
+        if (raw.inboxId === undefined || raw.inboxId.trim() === "") {
+          return toolError("Error: inboxId is required for download_attachment.");
+        }
+        if (raw.messageId === undefined || raw.messageId.trim() === "") {
+          return toolError("Error: messageId is required for download_attachment.");
+        }
+        if (raw.attachmentId === undefined || raw.attachmentId.trim() === "") {
+          return toolError("Error: attachmentId is required for download_attachment.");
+        }
+        const inboxId = raw.inboxId.trim();
+        const messageId = raw.messageId.trim();
+        const attachmentId = raw.attachmentId.trim();
+
+        const attachmentInfo = await getAgentmailAttachmentUrl(inboxId, messageId, attachmentId);
+        const { downloadUrl, filename: originalFilename, contentType: originalContentType, size } = attachmentInfo;
+
+        const response = await fetch(downloadUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to download attachment: HTTP ${response.status}`);
+        }
+
+        const filename = originalFilename ?? attachmentId;
+        const contentType = originalContentType ?? "application/octet-stream";
+
+        const { storedPath } = await saveAttachment(
+          Buffer.from(await response.arrayBuffer()),
+          filename,
+          contentType,
+        );
+
+        log.info(`[stavrobot] manage_agentmail download_attachment: saved ${filename} (${contentType}, ${size} bytes) to ${storedPath}`);
+
+        const resultText = `Attachment saved.\nPath: ${storedPath}\nFilename: ${filename}\nContent type: ${contentType}\nSize: ${size} bytes`;
+        return {
+          content: [{ type: "text" as const, text: resultText }],
+          details: { storedPath, filename, contentType, size },
+        };
+      }
+
+      return toolError(`Error: unknown action '${action}'. Valid actions: list_inboxes, list_threads, list_messages, get_message, delete_thread, download_attachment.`);
     },
   };
 }

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -77,8 +77,8 @@ beforeEach(() => {
 
 describe("handleGetAllowlistRequest", () => {
   it("returns 200 with allowlist and ownerIdentities", () => {
-    mockGetAllowlist.mockReturnValue({ signal: ["+1111111111"], telegram: [42], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: ["+1111111111"], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: ["+1111111111"], telegram: [42], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: ["+1111111111"], telegram: [], whatsapp: [], email: [], agentmail: [] });
 
     const response = makeMockResponse();
     const config = makeConfig({ owner: { name: "Owner", signal: "+1111111111" } });
@@ -94,8 +94,8 @@ describe("handleGetAllowlistRequest", () => {
   });
 
   it("calls getOwnerIdentities with the config", () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
 
     const response = makeMockResponse();
     const config = makeConfig();
@@ -106,8 +106,8 @@ describe("handleGetAllowlistRequest", () => {
   });
 
   it("includes notes in the response", () => {
-    mockGetAllowlist.mockReturnValue({ signal: ["+1111111111"], telegram: [], whatsapp: [], email: [], notes: { "+1111111111": "Mom" } });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: ["+1111111111"], telegram: [], whatsapp: [], email: [], agentmail: [], notes: { "+1111111111": "Mom" } });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
 
     const response = makeMockResponse();
     handleGetAllowlistRequest(response as unknown as http.ServerResponse, makeConfig());
@@ -119,8 +119,8 @@ describe("handleGetAllowlistRequest", () => {
 
 describe("handlePutAllowlistRequest", () => {
   it("saves the allowlist and returns 200 with updated data", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: ["+2222222222"], telegram: [99], whatsapp: [], email: [] });
@@ -131,7 +131,7 @@ describe("handlePutAllowlistRequest", () => {
     await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, config);
 
     expect(response.statusCode).toBe(200);
-    expect(mockSaveAllowlist).toHaveBeenCalledWith({ signal: ["+2222222222"], telegram: [99], whatsapp: [], email: [], notes: {} });
+    expect(mockSaveAllowlist).toHaveBeenCalledWith({ signal: ["+2222222222"], telegram: [99], whatsapp: [], email: [], agentmail: [], notes: {} });
     const parsed = JSON.parse(response.body!);
     expect(parsed.allowlist.signal).toEqual(["+2222222222"]);
     expect(parsed.allowlist.telegram).toEqual([99]);
@@ -204,8 +204,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("re-adds missing owner signal identity before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: ["+9999999999"], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: ["+9999999999"], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     // Submit without the owner's number.
@@ -222,8 +222,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("re-adds missing owner telegram identity before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [12345], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [12345], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     // Submit without the owner's chat ID.
@@ -240,8 +240,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("does not duplicate owner identity when already present in submitted list", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: ["+9999999999"], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: ["+9999999999"], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: ["+9999999999", "+1111111111"], telegram: [], whatsapp: [], email: [] });
@@ -255,8 +255,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("returns ownerIdentities in the response", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: ["+9999999999"], telegram: [12345], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: ["+9999999999"], telegram: [12345], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: ["+9999999999"], telegram: [12345], whatsapp: [], email: [] });
@@ -271,7 +271,7 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("returns 400 when signal contains a non-E.164 number", async () => {
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
 
     const request = makeMockRequest(JSON.stringify({ signal: ["banana"], telegram: [], whatsapp: [], email: [] }));
     const response = makeMockResponse();
@@ -285,7 +285,7 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("returns 400 when signal number is missing the leading plus sign", async () => {
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
 
     const request = makeMockRequest(JSON.stringify({ signal: ["12345678901"], telegram: [], whatsapp: [], email: [] }));
     const response = makeMockResponse();
@@ -298,7 +298,7 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("returns 400 when signal contains whitespace-only strings", async () => {
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
 
     const request = makeMockRequest(JSON.stringify({ signal: ["   "], telegram: [], whatsapp: [], email: [] }));
     const response = makeMockResponse();
@@ -311,8 +311,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("trims signal entries before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const request = makeMockRequest(JSON.stringify({ signal: ["  +1111111111  "], telegram: [], whatsapp: [], email: [] }));
@@ -326,8 +326,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("deduplicates signal entries before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const request = makeMockRequest(
@@ -343,8 +343,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("deduplicates telegram entries before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const request = makeMockRequest(JSON.stringify({ signal: [], telegram: [42, 99, 42], whatsapp: [], email: [] }));
@@ -358,8 +358,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("saves whatsapp entries and returns them in the response", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: [], telegram: [], whatsapp: ["+3333333333"], email: [] });
@@ -369,7 +369,7 @@ describe("handlePutAllowlistRequest", () => {
     await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, makeConfig());
 
     expect(response.statusCode).toBe(200);
-    expect(mockSaveAllowlist).toHaveBeenCalledWith({ signal: [], telegram: [], whatsapp: ["+3333333333"], email: [], notes: {} });
+    expect(mockSaveAllowlist).toHaveBeenCalledWith({ signal: [], telegram: [], whatsapp: ["+3333333333"], email: [], agentmail: [], notes: {} });
     const parsed = JSON.parse(response.body!);
     expect(parsed.allowlist.whatsapp).toEqual(["+3333333333"]);
   });
@@ -398,8 +398,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("deduplicates whatsapp entries before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const request = makeMockRequest(
@@ -415,8 +415,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("re-adds missing owner whatsapp identity before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: ["+8888888888"], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: ["+8888888888"], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     // Submit without the owner's WhatsApp number.
@@ -433,8 +433,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("accepts '*' as a valid signal entry and saves it", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: ["*"], telegram: [], whatsapp: [], email: [] });
@@ -449,8 +449,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("accepts '*' as a valid telegram entry and saves it", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: [], telegram: ["*"], whatsapp: [], email: [] });
@@ -465,8 +465,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("accepts '*' as a valid whatsapp entry and saves it", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: [], telegram: [], whatsapp: ["*"], email: [] });
@@ -492,8 +492,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("saves notes when provided and returns them in the response", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: ["+1111111111"], telegram: [], whatsapp: [], email: [], notes: { "+1111111111": "Mom" } });
@@ -510,8 +510,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("defaults notes to {} when absent from request body", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: ["+1111111111"], telegram: [], whatsapp: [], email: [] });
@@ -526,8 +526,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("prunes orphaned notes whose keys are not in any service list", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({
@@ -549,8 +549,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("keeps telegram notes using string keys", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({
@@ -594,8 +594,8 @@ describe("handlePutAllowlistRequest", () => {
     expect(parsed.error).toMatch(/notes/i);
   });
   it("saves email entries and returns them in the response", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: ["user@example.com"] });
@@ -605,7 +605,7 @@ describe("handlePutAllowlistRequest", () => {
     await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, makeConfig());
 
     expect(response.statusCode).toBe(200);
-    expect(mockSaveAllowlist).toHaveBeenCalledWith({ signal: [], telegram: [], whatsapp: [], email: ["user@example.com"], notes: {} });
+    expect(mockSaveAllowlist).toHaveBeenCalledWith({ signal: [], telegram: [], whatsapp: [], email: ["user@example.com"], agentmail: [], notes: {} });
     const parsed = JSON.parse(response.body!);
     expect(parsed.allowlist.email).toEqual(["user@example.com"]);
   });
@@ -655,8 +655,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("normalizes email addresses to lowercase before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: ["User@Example.COM"] });
@@ -671,8 +671,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("deduplicates email entries before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: ["a@b.com", "c@d.com", "a@b.com"] });
@@ -687,8 +687,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("accepts '*' as a valid email entry and saves it", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: ["*"] });
@@ -703,8 +703,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("re-adds missing owner email identity before saving", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: ["owner@example.com"] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: ["owner@example.com"], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     // Submit without the owner's email.
@@ -721,8 +721,8 @@ describe("handlePutAllowlistRequest", () => {
   });
 
   it("includes email entries in allEntryKeys so email notes are not pruned", async () => {
-    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], notes: {} });
-    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [] });
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
     mockSaveAllowlist.mockImplementation(() => undefined);
 
     const body = JSON.stringify({
@@ -740,6 +740,96 @@ describe("handlePutAllowlistRequest", () => {
     expect(response.statusCode).toBe(200);
     const saved = mockSaveAllowlist.mock.calls[0][0];
     expect(saved.notes).toEqual({ "user@example.com": "Work contact" });
+  });
+
+  it("saves agentmail entries and returns them in the response", async () => {
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
+    mockSaveAllowlist.mockImplementation(() => undefined);
+
+    const body = JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: ["user@agentmail.io"] });
+    const request = makeMockRequest(body);
+    const response = makeMockResponse();
+
+    await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, makeConfig());
+
+    expect(response.statusCode).toBe(200);
+    expect(mockSaveAllowlist).toHaveBeenCalledWith({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: ["user@agentmail.io"], notes: {} });
+    const parsed = JSON.parse(response.body!);
+    expect(parsed.allowlist.agentmail).toEqual(["user@agentmail.io"]);
+  });
+
+  it("returns 400 when agentmail is not an array of strings", async () => {
+    const request = makeMockRequest(JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [123] }));
+    const response = makeMockResponse();
+
+    await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, makeConfig());
+
+    expect(response.statusCode).toBe(400);
+    const parsed = JSON.parse(response.body!);
+    expect(parsed.error).toMatch(/agentmail/i);
+  });
+
+  it("returns 400 when agentmail contains an invalid address", async () => {
+    const request = makeMockRequest(JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: ["notanemail"] }));
+    const response = makeMockResponse();
+
+    await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, makeConfig());
+
+    expect(response.statusCode).toBe(400);
+    const parsed = JSON.parse(response.body!);
+    expect(parsed.error).toMatch(/notanemail/);
+  });
+
+  it("re-adds missing owner agentmail identity before saving", async () => {
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: ["owner@agentmail.io"] });
+    mockSaveAllowlist.mockImplementation(() => undefined);
+
+    // Submit without the owner's agentmail address.
+    const body = JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: ["other@agentmail.io"] });
+    const request = makeMockRequest(body);
+    const response = makeMockResponse();
+
+    await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, makeConfig());
+
+    expect(response.statusCode).toBe(200);
+    const saved = mockSaveAllowlist.mock.calls[0][0];
+    expect(saved.agentmail).toContain("owner@agentmail.io");
+    expect(saved.agentmail).toContain("other@agentmail.io");
+  });
+
+  it("preserves existing agentmail entries when agentmail is absent from request body", async () => {
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: ["existing@agentmail.io"], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
+    mockSaveAllowlist.mockImplementation(() => undefined);
+
+    // Body omits agentmail entirely — existing entries must not be wiped.
+    const body = JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: [] });
+    const request = makeMockRequest(body);
+    const response = makeMockResponse();
+
+    await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, makeConfig());
+
+    expect(response.statusCode).toBe(200);
+    const saved = mockSaveAllowlist.mock.calls[0][0];
+    expect(saved.agentmail).toContain("existing@agentmail.io");
+  });
+
+  it("uses empty agentmail when absent from request body and stored list is empty", async () => {
+    mockGetAllowlist.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [], notes: {} });
+    mockGetOwnerIdentities.mockReturnValue({ signal: [], telegram: [], whatsapp: [], email: [], agentmail: [] });
+    mockSaveAllowlist.mockImplementation(() => undefined);
+
+    const body = JSON.stringify({ signal: [], telegram: [], whatsapp: [], email: [] });
+    const request = makeMockRequest(body);
+    const response = makeMockResponse();
+
+    await handlePutAllowlistRequest(request, response as unknown as http.ServerResponse, makeConfig());
+
+    expect(response.statusCode).toBe(200);
+    const saved = mockSaveAllowlist.mock.calls[0][0];
+    expect(saved.agentmail).toEqual([]);
   });
 });
 
@@ -761,7 +851,7 @@ describe("serveAllowlistPage", () => {
     expect(response.body).toContain("<h1>Settings</h1>");
   });
 
-  it("returns HTML containing the Signal, Telegram, WhatsApp, and Email sections", () => {
+  it("returns HTML containing the Signal, Telegram, WhatsApp, Email, and Agentmail sections", () => {
     const response = makeMockResponse();
 
     serveAllowlistPage(response as unknown as http.ServerResponse);
@@ -770,5 +860,6 @@ describe("serveAllowlistPage", () => {
     expect(response.body).toContain("Telegram allowlist");
     expect(response.body).toContain("WhatsApp allowlist");
     expect(response.body).toContain("Email allowlist");
+    expect(response.body).toContain("Agentmail allowlist");
   });
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -150,11 +150,40 @@ export async function handlePutAllowlistRequest(
 
   const submittedNotes = (obj.notes ?? {}) as Record<string, string>;
 
+  // The agentmail field is optional for backward compatibility with clients that
+  // don't send it yet. When absent, preserve the existing stored entries rather
+  // than defaulting to [] which would silently wipe them.
+  const rawAgentmail = obj.agentmail !== undefined ? obj.agentmail : (getAllowlist().agentmail ?? []);
+  if (!Array.isArray(rawAgentmail) || !rawAgentmail.every((item) => typeof item === "string")) {
+    response.writeHead(400, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ error: "'agentmail' must be an array of strings" }));
+    return;
+  }
+
+  const trimmedAgentmail = (rawAgentmail as string[]).map((item) => item.trim().toLowerCase());
+  if (trimmedAgentmail.some((item) => item.length === 0)) {
+    response.writeHead(400, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ error: "'agentmail' must be an array of non-empty strings" }));
+    return;
+  }
+
+  const invalidAgentmail = trimmedAgentmail.find((item) => item !== "*" && !emailPattern.test(item));
+  if (invalidAgentmail !== undefined) {
+    response.writeHead(400, { "Content-Type": "application/json" });
+    response.end(
+      JSON.stringify({
+        error: `Invalid agentmail address "${invalidAgentmail}".`,
+      }),
+    );
+    return;
+  }
+
   const submitted: Allowlist = {
     signal: [...new Set(trimmedSignal)],
     telegram: [...new Set(obj.telegram as (number | string)[])],
     whatsapp: [...new Set(trimmedWhatsapp)],
     email: [...new Set(trimmedEmail)],
+    agentmail: [...new Set(trimmedAgentmail)],
     notes: submittedNotes,
   };
 
@@ -180,6 +209,11 @@ export async function handlePutAllowlistRequest(
       submitted.email.push(ownerEmail);
     }
   }
+  for (const ownerAgentmail of (ownerIdentities.agentmail ?? [])) {
+    if (!submitted.agentmail.includes(ownerAgentmail)) {
+      submitted.agentmail.push(ownerAgentmail);
+    }
+  }
 
   // Prune notes whose keys don't correspond to any entry in any service list.
   // Telegram entries are numbers in the array but string keys in the notes map.
@@ -188,6 +222,7 @@ export async function handlePutAllowlistRequest(
     ...submitted.telegram.map((entry) => String(entry)),
     ...submitted.whatsapp,
     ...submitted.email,
+    ...submitted.agentmail,
   ]);
   const prunedNotes: Record<string, string> = {};
   for (const [key, value] of Object.entries(submitted.notes)) {
@@ -339,6 +374,16 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
       </div>
     </div>
 
+    <div class="section">
+      <h2>Agentmail allowlist</h2>
+      <ul class="entry-list" id="agentmail-list"></ul>
+      <div class="add-row">
+        <input type="text" id="agentmail-input" placeholder="user@agentmail.io" />
+        <input type="text" id="agentmail-note-input" placeholder="Note (optional)" />
+        <button class="btn" onclick="addAgentmailEntry()">Add</button>
+      </div>
+    </div>
+
     <span id="status"></span>
   </div>
 
@@ -347,10 +392,12 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
     let telegramEntries = [];
     let whatsappEntries = [];
     let emailEntries = [];
+    let agentmailEntries = [];
     let ownerSignal = [];
     let ownerTelegram = [];
     let ownerWhatsapp = [];
     let ownerEmail = [];
+    let ownerAgentmail = [];
     let notes = {};
 
     function escapeHtml(text) {
@@ -440,11 +487,32 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
       }).join("");
     }
 
+    function renderAgentmailList() {
+      const list = document.getElementById("agentmail-list");
+      if (agentmailEntries.length === 0) {
+        list.innerHTML = '<li style="color:var(--color-text-muted);font-size:13px;">No entries.</li>';
+        return;
+      }
+      list.innerHTML = agentmailEntries.map((entry, index) => {
+        const isOwner = ownerAgentmail.includes(entry);
+        const note = notes[entry];
+        return \`<li>
+          <span class="entry-value">\${escapeHtml(entry)}</span>
+          \${note ? \`<span class="note-text">\${escapeHtml(note)}</span>\` : ""}
+          \${isOwner
+            ? '<span class="owner-label">(owner)</span>'
+            : \`<button class="btn btn-danger" onclick="removeAgentmailEntry(\${index})">Delete</button>\`
+          }
+        </li>\`;
+      }).join("");
+    }
+
     function isIdentifierInAnyList(key) {
       return signalEntries.includes(key) ||
         telegramEntries.map(String).includes(key) ||
         whatsappEntries.includes(key) ||
-        emailEntries.includes(key);
+        emailEntries.includes(key) ||
+        agentmailEntries.includes(key);
     }
 
     function removeSignalEntry(index) {
@@ -485,6 +553,16 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
         delete notes[entry];
       }
       renderEmailList();
+      saveAllowlist();
+    }
+
+    function removeAgentmailEntry(index) {
+      const entry = agentmailEntries[index];
+      agentmailEntries.splice(index, 1);
+      if (!isIdentifierInAnyList(entry)) {
+        delete notes[entry];
+      }
+      renderAgentmailList();
       saveAllowlist();
     }
 
@@ -606,6 +684,31 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
       saveAllowlist();
     }
 
+    function addAgentmailEntry() {
+      const input = document.getElementById("agentmail-input");
+      const noteInput = document.getElementById("agentmail-note-input");
+      const value = input.value.trim().toLowerCase();
+      if (!value) return;
+      if (value !== "*" && !/@[^@]+\\./.test(value)) {
+        setStatus("Invalid agentmail address.", true);
+        return;
+      }
+      if (agentmailEntries.includes(value)) {
+        setStatus("That agentmail address is already in the list.", true);
+        return;
+      }
+      const note = noteInput.value.trim();
+      if (note) {
+        notes[value] = note;
+      }
+      agentmailEntries.push(value);
+      input.value = "";
+      noteInput.value = "";
+      renderAgentmailList();
+      setStatus("", false);
+      saveAllowlist();
+    }
+
     function setStatus(text, isError) {
       const el = document.getElementById("status");
       el.textContent = text;
@@ -626,11 +729,13 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
         telegramEntries = data.allowlist.telegram.slice();
         whatsappEntries = data.allowlist.whatsapp.slice();
         emailEntries = data.allowlist.email.slice();
+        agentmailEntries = data.allowlist.agentmail.slice();
         notes = Object.assign({}, data.allowlist.notes);
         ownerSignal = data.ownerIdentities.signal.slice();
         ownerTelegram = data.ownerIdentities.telegram.slice();
         ownerWhatsapp = data.ownerIdentities.whatsapp.slice();
         ownerEmail = data.ownerIdentities.email.slice();
+        ownerAgentmail = data.ownerIdentities.agentmail.slice();
 
         document.getElementById("loading").style.display = "none";
         document.getElementById("content").style.display = "";
@@ -639,6 +744,7 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
         renderTelegramList();
         renderWhatsappList();
         renderEmailList();
+        renderAgentmailList();
       } catch (error) {
         document.getElementById("loading").style.display = "none";
         document.getElementById("content").style.display = "";
@@ -651,7 +757,7 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
         const response = await fetch("/api/settings/allowlist", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ signal: signalEntries, telegram: telegramEntries, whatsapp: whatsappEntries, email: emailEntries, notes }),
+          body: JSON.stringify({ signal: signalEntries, telegram: telegramEntries, whatsapp: whatsappEntries, email: emailEntries, agentmail: agentmailEntries, notes }),
         });
         const data = await response.json();
         if (response.ok) {
@@ -659,15 +765,18 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
           telegramEntries = data.allowlist.telegram.slice();
           whatsappEntries = data.allowlist.whatsapp.slice();
           emailEntries = data.allowlist.email.slice();
+          agentmailEntries = data.allowlist.agentmail.slice();
           notes = Object.assign({}, data.allowlist.notes);
           ownerSignal = data.ownerIdentities.signal.slice();
           ownerTelegram = data.ownerIdentities.telegram.slice();
           ownerWhatsapp = data.ownerIdentities.whatsapp.slice();
           ownerEmail = data.ownerIdentities.email.slice();
+          ownerAgentmail = data.ownerIdentities.agentmail.slice();
           renderSignalList();
           renderTelegramList();
           renderWhatsappList();
           renderEmailList();
+          renderAgentmailList();
           setStatus("", false);
         } else {
           setStatus(data.error || "Failed to save.", true);
@@ -703,6 +812,13 @@ const SETTINGS_PAGE_HTML = `<!DOCTYPE html>
     });
     document.getElementById("email-note-input").addEventListener("keydown", (event) => {
       if (event.key === "Enter") addEmailEntry();
+    });
+
+    document.getElementById("agentmail-input").addEventListener("keydown", (event) => {
+      if (event.key === "Enter") addAgentmailEntry();
+    });
+    document.getElementById("agentmail-note-input").addEventListener("keydown", (event) => {
+      if (event.key === "Enter") addAgentmailEntry();
     });
 
     loadAllowlistData();


### PR DESCRIPTION
This adds agentmail.to as an inbound channel - honestly it is a little simpler than manual cloudfare workers. 
agentmail.to is a email service build for agents with a nice free plan. 

Below a plan outline that could also be used for an llm to reproduce this change. 

```
This adds AgentMail (https://agentmail.to) as a messaging channel, following the same patterns as the existing email integration.
AgentMail API docs: https://docs.agentmail.to/llms.txt
1. Configuration
- Add an AgentmailConfig interface with apiKey: string to the config types.
- Add optional agentmail?: AgentmailConfig to the main Config interface.
- Add optional agentmail?: string to OwnerConfig (the owner's agentmail address).
- Add "agentmail" to the OWNER_CHANNELS array.
- Add [agentmail] section to config.example.toml.
2. Allowlist
- Add an agentmail: string[] field to the Allowlist interface, validated the same way as email (supports * wildcard and domain wildcards like *@example.com).
- Seed the owner's agentmail address into the allowlist on startup (same as email).
- Add isInAllowlist handling for "agentmail" service, reusing the existing matchesEmailEntry logic.
- Update getOwnerIdentities to include agentmail.
3. Owner identity and database
- Add ownerAgentmailEntries alongside the existing ownerEmailEntries for pattern matching.
- Update isOwnerIdentity to handle "agentmail" service using the same email-pattern matching.
- Update seedOwner to lowercase agentmail identities (same as email).
4. API client module (new file)
- New module wrapping the agentmail npm package SDK. Initialize a singleton AgentMailClient with the API key.
- Functions:
  - initializeAgentmailClient(apiKey) — create the client.
  - registerAgentmailWebhook(publicHostname) — on startup, list existing webhooks; reuse one if the URL matches, otherwise create a new one for message.received events. Return the webhook secret.
  - sendAgentmailMessage(inboxId, to, subject, text, replyToMessageId?, attachments?) — send or reply. Converts plain text to simple HTML paragraphs. Supports base64-encoded attachments.
  - getAgentmailAttachmentUrl(inboxId, messageId, attachmentId) — get download URL and metadata for an attachment.
  - listAgentmailInboxes() — list all inboxes.
  - listAgentmailThreads(inboxId, options?) — list threads in an inbox with pagination.
  - listAgentmailMessages(inboxId, options?) — list messages in an inbox with pagination.
  - getAgentmailMessage(inboxId, messageId) — get full message content.
  - deleteAgentmailThread(inboxId, threadId) — delete a thread.
5. Inbound webhook handler (new file)
- New module handling POST /agentmail/webhook.
- Verify webhook signatures using the svix npm package (AgentMail uses Svix for webhook delivery). Check svix-id, svix-timestamp, svix-signature headers.
- Only process message.received events; return 200 for all others.
- Extract sender email from the from field (handle both plain addresses and "Display Name <email>" format).
- Check sender against the agentmail allowlist; drop if not allowed.
- Format the message for the agent with a header line containing inbox ID, thread ID, and message ID (needed for replies), subject, and body content.
- Important: the agent receives both text and HTML versions of the email body when available. Prefer extracted_text over text and extracted_html over html (the extracted variants strip quoted reply history). The HTML section is labeled --- HTML version --- and passed raw (no stripping). This matters because some email clients (Gmail, Outlook) send forwarded emails as HTML-only.
- List attachments with filename, content type, size, and attachment ID.
- Enqueue the formatted message with source "agentmail" and the sender's email as the sender identifier.
6. Route and startup wiring
- Register POST /agentmail/webhook as a public route (no auth — it's verified by Svix signature).
- On startup, if config.agentmail is defined: initialize the client, register the webhook, store the webhook secret.
- Add "agentmail" to GATED_SOURCES and INTERACTIVE_SOURCES in the message queue (same as email).
- In the auth-failure handler, log a warning for agentmail senders (no inbox context to send a login link).
7. Agent tools
send_agentmail tool — send outgoing email via AgentMail. Follows the same pattern as send_email:
- Resolve recipient via display name or raw email address (interlocutor lookup).
- Enforce subagent recipient scoping and allowlist checks.
- Supports a single file attachment from the temp directory.
- Parameters: recipient, inboxId, subject, message, optional replyToMessageId, optional attachmentPath.
manage_agentmail tool — multi-action tool (like manage_files) for mailbox management:
- list_inboxes — list all inboxes with ID, email, display name.
- list_threads — list threads in an inbox with subject, senders, message count, preview, timestamp. Supports pagination (limit, pageToken).
- list_messages — list messages in an inbox with from, subject, timestamp, attachment count, preview. Supports pagination.
- get_message — get full message details: from, to, cc, subject, timestamp, text content (prefers extractedText), HTML content (prefers extractedHtml), and attachments list with IDs.
- delete_thread — delete a thread by inbox and thread ID.
- download_attachment — download an attachment by inbox, message, and attachment ID. Saves to the temp directory.
Both tools are registered when config.agentmail is defined. Both send_agentmail and manage_agentmail are added to the subagent tool allowlist.
8. Subagent scope fix
The checkSubagentRecipientScope function must normalize agentmail identifiers case-insensitively (same as email), since the recipient is lowercased before the check but stored identities may have mixed case.
9. Settings UI
- Add agentmail to the allowlist editor in the settings page (same pattern as the email section: validate addresses, support wildcards, preserve owner entries).
10. Dependencies
- agentmail npm package (SDK)
- svix npm package (webhook signature verification)
```