### PR TITLE
Send text replies back to external channels

### DIFF
--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -210,6 +210,44 @@ describe("processQueue non-retryable 400 error handling", () => {
   });
 });
 
+describe("successful external text replies", () => {
+  it("auto-sends a successful text response back to Telegram", async () => {
+    const configWithTelegram = { ...stubConfig, telegram: { botToken: "bot-token" } } as unknown as Config;
+    initializeQueue(stubAgent, stubPool, configWithTelegram);
+    mockIsOwnerIdentity.mockReturnValue(true);
+    mockHandlePrompt.mockResolvedValueOnce("Hello <Diego> & welcome");
+
+    const result = await enqueueMessage("hi", "telegram", "987654321");
+
+    expect(result).toBe("Hello <Diego> & welcome");
+    expect(mockSendTelegramMessage).toHaveBeenCalledOnce();
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith("bot-token", "987654321", "Hello &lt;Diego&gt; &amp; welcome");
+  });
+
+  it("does not auto-send empty text responses", async () => {
+    const configWithTelegram = { ...stubConfig, telegram: { botToken: "bot-token" } } as unknown as Config;
+    initializeQueue(stubAgent, stubPool, configWithTelegram);
+    mockIsOwnerIdentity.mockReturnValue(true);
+    mockHandlePrompt.mockResolvedValueOnce("   ");
+
+    const result = await enqueueMessage("hi", "telegram", "987654321");
+
+    expect(result).toBe("   ");
+    expect(mockSendTelegramMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-send CLI text responses", async () => {
+    mockHandlePrompt.mockResolvedValueOnce("Hello");
+
+    const result = await enqueueMessage("hi");
+
+    expect(result).toBe("Hello");
+    expect(mockSendTelegramMessage).not.toHaveBeenCalled();
+    expect(mockSendSignalMessage).not.toHaveBeenCalled();
+    expect(mockSendWhatsappTextMessage).not.toHaveBeenCalled();
+  });
+});
+
 describe("parseProviderErrorMessage", () => {
   it("extracts the message field from a 400 provider error JSON", () => {
     const raw = 'Agent error: "400 {"type":"error","error":{"type":"invalid_request_error","message":"orphaned tool_result"}}"';

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -251,6 +251,41 @@ async function sendErrorToSource(
   }
 }
 
+function escapeTelegramHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+async function sendTextResponseToSource(
+  source: string | undefined,
+  sender: string | undefined,
+  config: Config,
+  message: string,
+): Promise<void> {
+  const text = message.trim();
+  if (text === "" || sender === undefined) {
+    return;
+  }
+
+  if (source === "signal") {
+    const sendResult = await sendSignalMessage(sender, text);
+    if (sendResult === "rate_limited") {
+      log.warn("[stavrobot] Failed to auto-send Signal response: rate limited");
+    }
+  } else if (source === "telegram") {
+    if (config.telegram === undefined) {
+      log.warn("[stavrobot] Failed to auto-send Telegram response: Telegram is not configured.");
+      return;
+    }
+    log.info(`[stavrobot] message out: telegram - ${sender} - ${text.slice(0, 200)}`);
+    await sendTelegramMessage(config.telegram.botToken, sender, escapeTelegramHtml(text));
+  } else if (source === "whatsapp") {
+    await sendWhatsappTextMessage(sender, text);
+  }
+}
+
 async function processQueue(): Promise<void> {
   processing = true;
   while (queue.length > 0) {
@@ -266,6 +301,7 @@ async function processQueue(): Promise<void> {
         continue;
       }
       const response = await handlePrompt(queueAgent!, queuePool!, entry.message, queueConfig!, routing, entry.source, entry.attachments, entry.retries > 0);
+      await sendTextResponseToSource(entry.source, entry.sender, queueConfig!, response);
       entry.resolve(response);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Stavrobot can receive and route inbound external-channel messages correctly while still failing to deliver a successful plain-text assistant response back to that same channel.

The queue awaits `handlePrompt()` and resolves the returned response text to its caller. For webhook-driven channels such as Telegram, the webhook handler starts `enqueueMessage()` asynchronously and does not consume that returned string. If the model responds with plain text instead of explicitly calling the channel-specific send tool, the response is persisted in history but no outbound API call is made.

This PR adds a queue-level fallback for successful non-empty text responses from external channels:

- Signal responses are sent back with `sendSignalMessage`.
- Telegram responses are HTML-escaped and sent back with `sendTelegramMessage`.
- WhatsApp responses are sent back with `sendWhatsappTextMessage`.
- CLI/internal responses are left unchanged.
- Empty responses are not sent.
- Existing error-delivery behavior is unchanged.

The system prompt already instructs the model to use channel-specific send tools for external sources, but this fallback makes delivery robust when the model returns normal text anyway.

## Tests

- `docker build --target build -t stavrobot-build-check .`
- `docker run --rm stavrobot-build-check npm test -- src/queue.test.ts`
