### PR TITLE
Add optional async acknowledgement to POST /chat

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,6 +43,14 @@ External caller (Telegram / Signal / WhatsApp / email / Pebble Index / CLI)
 
 Webhook handlers acknowledge the request before their queued message is processed.
 
+`POST /chat` also accepts an optional boolean `async` field. With `async: true`, the
+handler validates the request and submits it through `enqueueMessage` once, then returns
+`202 {"accepted":true}` without awaiting the turn. When the field is omitted or `false`,
+the caller waits for the normal response string. The async path does not bypass the
+queue, so its serialization, routing, `/stop`, and owner-steering behavior remain the
+same. A present non-boolean `async` value is rejected before raw file attachments are
+written.
+
 Owner messages arriving while a turn is in progress are **steered** into the running
 turn via `Agent.steer()` rather than queued. Non-owner messages are always queued.
 

--- a/README.md
+++ b/README.md
@@ -172,8 +172,10 @@ JSON objects of the form `{"error": "..."}`.
 Sends a message to the agent and returns its reply. This is the main entry point: the web
 UI, the Signal bridge, the plugin runner, the coder, and the cron scheduler all use it.
 
-Messages are processed one at a time through a single queue. The request blocks until
-the agent has finished its turn, which can take a while if the agent uses tools.
+Messages are processed one at a time through a single queue. By default, the request
+blocks until the agent has finished its turn, which can take a while if the agent uses
+tools. Set `"async": true` to acknowledge after the message is submitted through
+`enqueueMessage` without waiting for the turn to finish.
 
 Request body is a JSON object (maximum 25 MB) with these fields. At least one of
 `message`, `files`, or `attachments` is required.
@@ -181,6 +183,7 @@ Request body is a JSON object (maximum 25 MB) with these fields. At least one of
 | Field | Type | Description |
 | --- | --- | --- |
 | `message` | string | The text to send to the agent. |
+| `async` | boolean | Optional. Set to the literal `true` to receive `202` with `{"accepted":true}` after submission instead of waiting for the reply. Omit it or set it to `false` to wait normally. Other values are rejected. |
 | `source` | string | The channel the message came from. Controls routing (see below) and is shown to the agent alongside the message. Omit it for direct calls; the agent then sees `cli`. |
 | `sender` | string | Who sent the message within that channel: an E.164 phone number for `signal` and `whatsapp`, a chat ID for `telegram`, an email address for `email`. Shown to the agent. |
 | `files` | array | Files sent inline. Each entry is `{ "data": "<base64>", "filename": "...", "mimeType": "..." }`. Files larger than 10 MB after decoding are skipped with a warning in the logs. Use this from outside the app container. |
@@ -199,24 +202,38 @@ Routing by `source`:
 
 Two special cases:
 
-- If the message is exactly `/stop`, the running agent turn is aborted and the response is
-  `Aborted.`. Nothing is queued.
+- If the message is exactly `/stop`, the running agent turn is aborted. Nothing is queued.
+  A synchronous request receives `Aborted.`.
 - If the agent is busy with one of your messages and another message from you arrives, the
-  new message is injected into the running turn instead of being queued. The response is
-  `Message received, steering the current request.`; the agent's reply to it becomes part
-  of the running turn, and is returned to whoever made the request that started that turn.
+  new message is injected into the running turn instead of being queued. A synchronous
+  steering request receives `Message received, steering the current request.` The agent's
+  reply becomes part of the running turn and is returned only when the HTTP request that
+  started that turn is synchronous.
 
-Response: `200` with `{"response": "<agent reply>"}`. A dropped message (unknown sender on
-a gated channel) also returns `200`, with an empty `response` string.
+Response: with `async` omitted or set to `false`, `200` with
+`{"response": "<agent reply>"}`. With `async: true`, the response is `202` with
+`{"accepted":true}`; it follows the same enqueue path, preserving routing, `/stop`, and
+owner steering behavior, but no agent reply is returned to that request. For synchronous
+calls, a dropped message (unknown sender on a gated channel) also returns `200`, with an
+empty `response` string.
 
-Errors: `400` for invalid JSON or a body with none of the required fields, `401` for a
-missing or wrong password, `413` if the body exceeds 25 MB, `500` for anything else.
+The acknowledgement confirms submission to the in-memory queue, not eventual completion.
+Queued work is lost if the app restarts before processing it, and any later enqueue
+rejection is logged because the HTTP response has already been sent.
+
+Errors: `400` for invalid JSON, a body with none of the required fields, or a present
+non-boolean `async` field; `401` for a missing or wrong password, `413` if the body
+exceeds 25 MB, `500` for anything else.
 
 Examples:
 
 ```bash
 curl -u :yourpassword -H 'Content-Type: application/json' \
   -d '{"message": "What is on my calendar today?"}' \
+  http://localhost:10567/chat
+
+curl -u :yourpassword -H 'Content-Type: application/json' \
+  -d '{"message": "Process this in the background.", "async": true}' \
   http://localhost:10567/chat
 
 curl -u :yourpassword -H 'Content-Type: application/json' \

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,9 @@ import { describe, it, expect, vi } from "vitest";
 import { handlePageQueryRequest, handleTelegramWebhookRequest, checkBasicAuth, readRequestBody, handleChatRequest } from "./index.js";
 import type { Pool, QueryResult } from "pg";
 import type { TelegramConfig } from "./config.js";
+import { log } from "./log.js";
+import { enqueueMessage } from "./queue.js";
+import { saveAttachment } from "./uploads.js";
 
 // Mock queue and uploads so handleChatRequest tests don't need real infrastructure.
 vi.mock("./queue.js", () => ({
@@ -301,6 +304,22 @@ function makeBodyRequest(body: Buffer, headers: Record<string, string> = {}): ht
   }) as unknown as http.IncomingMessage;
 }
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T) => void = () => {};
+  let rejectPromise: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
 describe("readRequestBody size limit", () => {
   it("returns the body when it is within the limit", async () => {
     const body = Buffer.from(JSON.stringify({ message: "hello" }));
@@ -332,8 +351,7 @@ describe("handleChatRequest body size limit", () => {
 
 describe("handleChatRequest base64 file handling", () => {
   it("saves a small base64 file and returns 200", async () => {
-    const { saveAttachment: mockSaveAttachment } = await import("./uploads.js");
-    const saveMock = vi.mocked(mockSaveAttachment);
+    const saveMock = vi.mocked(saveAttachment);
     saveMock.mockClear();
 
     const smallBase64 = Buffer.from("hello world").toString("base64");
@@ -366,5 +384,129 @@ describe("handleChatRequest base64 file handling", () => {
     await handleChatRequest(request, response as unknown as http.ServerResponse);
 
     expect(response.statusCode).toBe(413);
+  });
+});
+
+describe("handleChatRequest async acknowledgement", () => {
+  it("acknowledges a request while its queue processing remains pending", async () => {
+    const mockEnqueue = vi.mocked(enqueueMessage);
+    mockEnqueue.mockClear();
+    const deferred = createDeferred<string>();
+    mockEnqueue.mockReturnValueOnce(deferred.promise);
+
+    const request = makeBodyRequest(Buffer.from(JSON.stringify({
+      message: "test",
+      source: "signal",
+      sender: "+1234567890",
+      async: true,
+    })));
+    const response = makeMockResponse();
+
+    await handleChatRequest(request, response as unknown as http.ServerResponse);
+
+    expect(response.statusCode).toBe(202);
+    expect(response.body).toBe(JSON.stringify({ accepted: true }));
+    expect(mockEnqueue).toHaveBeenCalledOnce();
+    expect(mockEnqueue).toHaveBeenCalledWith("test", "signal", "+1234567890", undefined);
+
+    deferred.resolve("complete");
+  });
+
+  for (const { label, payload } of [
+    { label: "omitted", payload: { message: "test" } },
+    { label: "false", payload: { message: "test", async: false } },
+  ]) {
+    it(`waits for queue processing when async is ${label}`, async () => {
+      const mockEnqueue = vi.mocked(enqueueMessage);
+      mockEnqueue.mockClear();
+      const deferred = createDeferred<string>();
+      mockEnqueue.mockReturnValueOnce(deferred.promise);
+
+      const request = makeBodyRequest(Buffer.from(JSON.stringify(payload)));
+      const response = makeMockResponse();
+      const requestPromise = handleChatRequest(request, response as unknown as http.ServerResponse);
+
+      await vi.waitFor(() => {
+        expect(mockEnqueue).toHaveBeenCalledOnce();
+      });
+      expect(response.statusCode).toBeUndefined();
+
+      deferred.resolve("complete");
+      await requestPromise;
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBe(JSON.stringify({ response: "complete" }));
+    });
+  }
+
+  for (const { label, asyncValue } of [
+    { label: "string", asyncValue: "true" },
+    { label: "number", asyncValue: 1 },
+    { label: "null", asyncValue: null },
+    { label: "object", asyncValue: {} },
+    { label: "array", asyncValue: [] },
+  ]) {
+    it(`rejects a ${label} async value before file writes or enqueueing`, async () => {
+      const mockEnqueue = vi.mocked(enqueueMessage);
+      const mockSaveAttachment = vi.mocked(saveAttachment);
+      mockEnqueue.mockClear();
+      mockSaveAttachment.mockClear();
+
+      const request = makeBodyRequest(Buffer.from(JSON.stringify({
+        message: "test",
+        async: asyncValue,
+        files: [{ data: Buffer.from("file").toString("base64"), filename: "file.txt", mimeType: "text/plain" }],
+      })));
+      const response = makeMockResponse();
+
+      await handleChatRequest(request, response as unknown as http.ServerResponse);
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body ?? "{}").error).toMatch(/async.*boolean/i);
+      expect(mockSaveAttachment).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+  }
+
+  it("keeps required-content validation for async requests", async () => {
+    const mockEnqueue = vi.mocked(enqueueMessage);
+    mockEnqueue.mockClear();
+    const request = makeBodyRequest(Buffer.from(JSON.stringify({ async: true })));
+    const response = makeMockResponse();
+
+    await handleChatRequest(request, response as unknown as http.ServerResponse);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toBe(JSON.stringify({ error: "At least one of 'message', 'attachments', or 'files' must be present" }));
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("logs a detached enqueue rejection without sending another response", async () => {
+    const mockEnqueue = vi.mocked(enqueueMessage);
+    mockEnqueue.mockClear();
+    const deferred = createDeferred<string>();
+    mockEnqueue.mockReturnValueOnce(deferred.promise);
+    const error = new Error("queue failed");
+    const logErrorSpy = vi.spyOn(log, "error").mockImplementation(() => {});
+    const request = makeBodyRequest(Buffer.from(JSON.stringify({ message: "test", async: true })));
+    const response = makeMockResponse();
+    const writeHeadSpy = vi.spyOn(response, "writeHead");
+    const endSpy = vi.spyOn(response, "end");
+
+    try {
+      await handleChatRequest(request, response as unknown as http.ServerResponse);
+      deferred.reject(error);
+
+      await vi.waitFor(() => {
+        expect(logErrorSpy).toHaveBeenCalledWith("[stavrobot] Error processing asynchronous chat request:", error);
+      });
+
+      expect(response.statusCode).toBe(202);
+      expect(response.body).toBe(JSON.stringify({ accepted: true }));
+      expect(writeHeadSpy).toHaveBeenCalledOnce();
+      expect(endSpy).toHaveBeenCalledOnce();
+    } finally {
+      logErrorSpy.mockRestore();
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,16 @@ export async function handleChatRequest(
       return;
     }
 
+    let asyncRequested = false;
+    if ("async" in parsedBody) {
+      if (typeof parsedBody.async !== "boolean") {
+        response.writeHead(400, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: "'async' must be a boolean" }));
+        return;
+      }
+      asyncRequested = parsedBody.async;
+    }
+
     const message = "message" in parsedBody && typeof parsedBody.message === "string" ? parsedBody.message : undefined;
 
     let attachments: FileAttachment[] | undefined;
@@ -214,7 +224,18 @@ export async function handleChatRequest(
       return;
     }
 
-    const assistantResponse = await enqueueMessage(message, source, sender, combinedAttachments);
+    const enqueuePromise = enqueueMessage(message, source, sender, combinedAttachments);
+    if (asyncRequested) {
+      // Keep async calls on the same queue so ordering and owner steering still apply.
+      void enqueuePromise.catch((error: unknown) => {
+        log.error("[stavrobot] Error processing asynchronous chat request:", error);
+      });
+      response.writeHead(202, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ accepted: true }));
+      return;
+    }
+
+    const assistantResponse = await enqueuePromise;
 
     response.writeHead(200, { "Content-Type": "application/json" });
     response.end(JSON.stringify({ response: assistantResponse }));


### PR DESCRIPTION
## Summary
- Adds a strict optional `async` boolean to `POST /chat`.
- `async: true` submits through the existing enqueue path and responds with `202 {"accepted":true}`; omitted or `false` retains the synchronous `200 {"response":...}` contract.
- Preserves authentication, routing, `/stop`, serial queue behavior, and current owner steering behavior.
- Documents the in-memory acknowledgement limitation: queued work can be lost on restart, and a post-acknowledgement enqueue rejection is logged without another HTTP response.

## Validation
- `npm test -- src/index.test.ts src/queue.test.ts` — 3 files / 76 tests passed.
- `npm test` — 23 files / 664 tests passed.
- `npx tsc --noEmit` — passed.
- `npm run build` — passed.
- `docker compose build` — blocked because no Docker daemon was available at `unix:///var/run/docker.sock`.

Linear: STA-224